### PR TITLE
Fixes bug in mcap merge coordinator

### DIFF
--- a/mcap/merge.go
+++ b/mcap/merge.go
@@ -73,6 +73,7 @@ func (c *MergeCoordinator) Write(schema *mcap.Schema, channel *mcap.Channel, msg
 		if mappedID, ok := c.schemaHashes[schemaHash]; ok {
 			// associate this schemau with the mapped ID
 			c.schemas[schema] = mappedID
+			schemaID = mappedID
 		} else {
 			schemaID = c.nextSchemaID
 			newSchema := &mcap.Schema{

--- a/mcap/testutils.go
+++ b/mcap/testutils.go
@@ -21,11 +21,12 @@ func ReadFile(t *testing.T, r io.Reader) []uint64 {
 
 	var timestamps []uint64
 	for {
-		_, _, msg, err := msgs.Next(nil)
+		schema, _, msg, err := msgs.Next(nil)
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)
+		require.NotNil(t, schema, "got a nil schema")
 		timestamps = append(timestamps, msg.LogTime)
 	}
 	return timestamps

--- a/treemgr/treemgr_test.go
+++ b/treemgr/treemgr_test.go
@@ -393,7 +393,15 @@ func TestStreamingAcrossMultipleReceives(t *testing.T) {
 	info, err := reader.Info()
 	require.NoError(t, err)
 	require.Equal(t, 3, int(info.Statistics.MessageCount))
+
+	require.Len(t, info.Schemas, 1)
+	for _, channel := range info.Channels {
+		require.Equal(t, "topic-0", channel.Topic)
+		schema := info.Schemas[channel.SchemaID]
+		require.NotNil(t, schema)
+	}
 }
+
 func TestReceive(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {

--- a/util/testutils/testutils.go
+++ b/util/testutils/testutils.go
@@ -52,20 +52,32 @@ func U32b(v uint32) []byte {
 	return buf
 }
 
+// U64b returns a byte slice containing a single uint64 value.
 func U64b(v uint64) []byte {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, v)
 	return buf
 }
 
+// F32b returns a byte slice containing a single float32 value.
 func F32b(v float32) []byte {
 	return U32b(math.Float32bits(v))
 }
 
+// F64b returns a byte slice containing a single float64 value.
 func F64b(v float64) []byte {
 	return U64b(math.Float64bits(v))
 }
 
+// PrefixedString returns a byte slice containing a string prefixed with its length.
+func PrefixedString(s string) []byte {
+	buf := make([]byte, 4+len(s))
+	binary.LittleEndian.PutUint32(buf, uint32(len(s)))
+	copy(buf[4:], s)
+	return buf
+}
+
+// ReadPrefixedString reads a string from a byte slice.
 func ReadPrefixedString(t *testing.T, bs []byte) string {
 	t.Helper()
 	if len(bs) < 4 {


### PR DESCRIPTION
Prior to this commit, if we received two inputs with identical-hashing schemas but different-hashing channels, we associated the output message with an incorrect zero-valued schema ID.