### PR TITLE
Add WAL garbage collection

### DIFF
--- a/service/dp3.go
+++ b/service/dp3.go
@@ -67,7 +67,8 @@ func (dp3 *DP3) Start(ctx context.Context, options ...DP3Option) error { //nolin
 	}
 	vs := versionstore.NewSQLVersionstore(db, 1e9)
 	walopts := []wal.Option{
-		wal.WithInactiveBatchMergeInterval(2),
+		wal.WithInactiveBatchMergeInterval(2 * time.Second),
+		wal.WithGCInterval(2 * time.Minute),
 	}
 	waldir := "waldir"
 	tmgr, err := treemgr.NewTreeManager(

--- a/wal/options.go
+++ b/wal/options.go
@@ -14,6 +14,7 @@ type config struct {
 	targetFileSize      int
 
 	inactiveBatchMergeInterval time.Duration
+	gcInterval                 time.Duration
 }
 
 // Option is a function that modifies the WAL manager configuration.
@@ -25,6 +26,14 @@ type Option func(*config)
 func WithMergeSizeThreshold(size int) Option {
 	return func(c *config) {
 		c.mergeSizeThreshold = size
+	}
+}
+
+// WithGCInterval sets the interval at which the WAL manager will check for
+// stale WAL files to remove.
+func WithGCInterval(d time.Duration) Option {
+	return func(c *config) {
+		c.gcInterval = d
 	}
 }
 
@@ -46,8 +55,8 @@ func WithTargetFileSize(size int) Option {
 }
 
 // WithInactiveBatchMergeInterval sets the polling interval to check for inactive batches.
-func WithInactiveBatchMergeInterval(secs int) Option {
+func WithInactiveBatchMergeInterval(d time.Duration) Option {
 	return func(c *config) {
-		c.inactiveBatchMergeInterval = time.Duration(secs) * time.Second
+		c.inactiveBatchMergeInterval = d
 	}
 }


### PR DESCRIPTION
Prior to this commit we would accumulate WAL indefinitely. Now we scan the WAL's state at an interval and reap any files that are not referenced by anything in pending state. By default the interval is every two minutes. The active file is never reaped.