### PR TITLE
Add initial support for `DeleteMessagesInRange`, refactor merge and insert methods

### DIFF
--- a/nodestore/inner_node.go
+++ b/nodestore/inner_node.go
@@ -24,7 +24,7 @@ change, and we will be in a better position to design a compact format.
 // bytes 0-128 and leaf nodes get 129-256.
 const innerNodeVersion = uint8(1)
 
-// InnerNode represents an interior node in the tree, with slots for 64
+// InnerNode represents an interior node in the tree, with slots for branchingFactor
 // children.
 type InnerNode struct {
 	Start    uint64   `json:"start"`
@@ -76,6 +76,15 @@ func (n *InnerNode) PlaceChild(index uint64, id NodeID, version uint64, statisti
 		ID:         id,
 		Version:    version,
 		Statistics: statistics,
+	}
+}
+
+// PlaceTombstoneChild inserts a tombstone for the child at the given index with the given version.
+func (n *InnerNode) PlaceTombstoneChild(index uint64, version uint64) {
+	n.Children[index] = &Child{
+		ID:         NodeID{},
+		Version:    version,
+		Statistics: nil,
 	}
 }
 

--- a/tree/byo.go
+++ b/tree/byo.go
@@ -40,7 +40,7 @@ func (t *byoTreeReader) GetLeafData(ctx context.Context, id nodestore.NodeID) (
 
 	leaf, ok := node.(*nodestore.LeafNode)
 	if !ok {
-		return ancestor, nil, newUnexpectedNodeError(nodestore.Leaf, node)
+		return ancestor, nil, NewUnexpectedNodeError(nodestore.Leaf, node)
 	}
 	return leaf.Ancestor(), util.NewReadSeekNopCloser(leaf.Data()), nil
 }

--- a/tree/errors.go
+++ b/tree/errors.go
@@ -30,7 +30,7 @@ func (e UnexpectedNodeError) Is(target error) bool {
 	return ok
 }
 
-func newUnexpectedNodeError(expected nodestore.NodeType, found nodestore.Node) error {
+func NewUnexpectedNodeError(expected nodestore.NodeType, found nodestore.Node) error {
 	return UnexpectedNodeError{
 		expected: expected,
 		found:    found,

--- a/tree/memtree.go
+++ b/tree/memtree.go
@@ -105,7 +105,7 @@ func (m *MemTree) ToBytes(ctx context.Context, oid uint64) ([]byte, error) { // 
 	}
 	node, ok := root.(*nodestore.InnerNode)
 	if !ok {
-		return nil, newUnexpectedNodeError(nodestore.Inner, root)
+		return nil, NewUnexpectedNodeError(nodestore.Inner, root)
 	}
 	path := []nodestore.NodeID{m.root}
 	nodes := []*nodestore.InnerNode{node}

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 
 	fmcap "github.com/foxglove/mcap/go/mcap"
 	"github.com/wkalt/dp3/mcap"
@@ -23,52 +24,45 @@ module.
 
 // //////////////////////////////////////////////////////////////////////////////
 
-// Insert writes the provided slice of data into the supplied tree writer, into
+// Insert writes the provided slice of data into a new (empty) tree writer, into
 // the leaf of the tree that spans the requested timestamp. Assuming no error,
-// after insert has returned the tree writer will reflect a partial tree from
-// root to leaf. In practice the tree writer passed to insert is always a
-// "memtree". The partial trees that result from insert are serialized to the
+// after insert has returned, the tree writer will reflect a partial tree from
+// root to leaf. The partial trees that result from insert are serialized to the
 // WAL, and later merged into the main tree in batches by the tree manager.
 //
-// Accordingly and confusingly, "insert" is only ever called on empty trees, and
-// the test helpers for insertion combine it with a merge operation to produce
-// more interesting examples.
+// Note that the root is merely used as a template for determining the structure
+// of the partial tree.
 func Insert(
 	ctx context.Context,
-	tw TreeWriter,
+	root *nodestore.InnerNode,
 	version uint64,
 	timestamp uint64,
 	data []byte,
 	statistics map[string]*nodestore.Statistics,
-) error {
-	oldRootID := tw.Root()
-	oldRootNode, err := tw.Get(ctx, oldRootID)
-	if err != nil {
-		return nodestore.NodeNotFoundError{NodeID: oldRootID}
+) (*MemTree, error) {
+	if root == nil {
+		return nil, errors.New("root is nil")
 	}
-	oldroot, ok := oldRootNode.(*nodestore.InnerNode)
-	if !ok || oldroot == nil {
-		return newUnexpectedNodeError(nodestore.Inner, oldroot)
+	tw := NewMemTree(nodestore.RandomNodeID(), nil)
+	if timestamp < root.Start*1e9 || timestamp >= root.End*1e9 {
+		return nil, OutOfBoundsError{timestamp, root.Start, root.End}
 	}
-	if timestamp < oldroot.Start*1e9 || timestamp >= oldroot.End*1e9 {
-		return OutOfBoundsError{timestamp, oldroot.Start, oldroot.End}
-	}
-	root := nodestore.NewInnerNode(
-		oldroot.Height,
-		oldroot.Start,
-		oldroot.End,
-		len(oldroot.Children),
+	clonedRoot := nodestore.NewInnerNode(
+		root.Height,
+		root.Start,
+		root.End,
+		len(root.Children),
 	)
-	ids := make([]nodestore.NodeID, 0, oldroot.Height+1)
-	for range oldroot.Height + 1 {
+	ids := make([]nodestore.NodeID, 0, root.Height+1)
+	for range root.Height + 1 {
 		id := nodestore.RandomNodeID()
 		ids = append(ids, id)
 	}
 	rootID := ids[0]
-	if err := tw.Put(ctx, rootID, root); err != nil {
-		return fmt.Errorf("failed to store new root: %w", err)
+	if err := tw.Put(ctx, rootID, clonedRoot); err != nil {
+		return nil, fmt.Errorf("failed to store new root: %w", err)
 	}
-	current := root
+	current := clonedRoot
 	for i := 1; current.Height > 1; i++ {
 		bucket := bucket(timestamp, current)
 		bwidth := bwidth(current)
@@ -79,7 +73,7 @@ func Insert(
 			len(current.Children),
 		)
 		if err := tw.Put(ctx, ids[i], node); err != nil {
-			return fmt.Errorf("failed to store inner node: %w", err)
+			return nil, fmt.Errorf("failed to store inner node: %w", err)
 		}
 		current.PlaceChild(bucket, ids[i], version, statistics)
 		current = node
@@ -89,11 +83,87 @@ func Insert(
 	bucket := bucket(timestamp, current)
 	node := nodestore.NewLeafNode(data, nil, nil)
 	if err := tw.Put(ctx, nodeID, node); err != nil {
-		return fmt.Errorf("failed to store leaf node: %w", err)
+		return nil, fmt.Errorf("failed to store leaf node: %w", err)
 	}
 	current.PlaceChild(bucket, nodeID, version, statistics)
 	tw.SetRoot(rootID)
-	return nil
+	return tw, nil
+}
+
+// DeleteMessagesInRange constructs a partial tree that represents the deletion
+// of messages in the given range. Start (inclusive) and end (exclusive) times
+// are expected in nanoseconds. The tree writer returned by this function is
+// expected to be serialized to the WAL and later merged into the main tree by
+// the tree manager.
+//
+// Tombstones are placed in the tree at the location of children that are fully
+// contained within the range. The partial tree, consisting of all nodes on the
+// path to deletion (excluding the deleted nodes themselves, which have been
+// tombstoned in their parents' children arrays), is returned.
+//
+// As before, the root is merely used as a template for determining the structure
+// of the partial tree.
+//
+// TODO: add support for statistics reconciliation (currently nil'd on the
+// path to deletion).
+func DeleteMessagesInRange(
+	ctx context.Context,
+	root *nodestore.InnerNode,
+	version uint64,
+	start uint64,
+	end uint64,
+) (*MemTree, error) {
+	if root == nil {
+		return nil, errors.New("root is nil")
+	}
+	tw := NewMemTree(nodestore.RandomNodeID(), root)
+	if start >= end {
+		return nil, fmt.Errorf("invalid range: start %d cannot be >= end %d", start, end)
+	}
+	if start >= root.End*1e9 || end < root.Start*1e9 {
+		return nil, fmt.Errorf("range [%d, %d) out of bounds [%d, %d)", start, end, root.Start*1e9, root.End*1e9)
+	}
+	clonedRoot := nodestore.NewInnerNode(root.Height, root.Start, root.End, len(root.Children))
+	clonedRootID := nodestore.RandomNodeID()
+	if err := tw.Put(ctx, clonedRootID, clonedRoot); err != nil {
+		return nil, fmt.Errorf("failed to store new root: %w", err)
+	}
+	stack := []*nodestore.InnerNode{clonedRoot}
+	for len(stack) > 0 {
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		// The node is partially within the range, i.e. either the start or end
+		// of the range is within the node. Descend into only the appropriate children.
+		// for i, child := range node.Children {
+		for i := range len(node.Children) {
+			childStart := node.Start + bwidth(node)*uint64(i)
+			childEnd := node.Start + bwidth(node)*uint64(i+1)
+			if start >= childEnd*1e9 || end <= childStart*1e9 {
+				// The child is entirely outside the range.
+				continue
+			}
+			if start <= childStart*1e9 && end >= childEnd*1e9 { // TODO: check bounds
+				// The entire child is within the range.
+				node.PlaceTombstoneChild(uint64(i), uint64(0))
+				continue
+			}
+			// The child is partially within the range.
+			// If the child is a leaf, error out...
+			if node.Height == 1 {
+				return nil, errors.New("range cannot partially span a leaf node")
+			}
+			clonedChild := nodestore.NewInnerNode(node.Height-1, childStart, childEnd, len(node.Children))
+			clonedChildID := nodestore.RandomNodeID()
+			if err := tw.Put(ctx, clonedChildID, clonedChild); err != nil {
+				return nil, fmt.Errorf("failed to store new inner node: %w", err)
+			}
+			bucket := bucket(start, node)
+			node.PlaceChild(bucket, clonedChildID, version, nil)
+			stack = append(stack, clonedChild)
+		}
+	}
+	tw.SetRoot(clonedRootID)
+	return tw, nil
 }
 
 // GetStatRange returns the statistics for the given range of time, for the tree
@@ -143,13 +213,30 @@ func GetStatRange(
 	return ranges, nil
 }
 
+// sortByChildVersion sorts the provided inner nodes by the version of the child
+// at the given index (in ascending order).
+func sortByChildVersion(nodes []*nodestore.InnerNode, index int) []*nodestore.InnerNode {
+	sorted := make([]*nodestore.InnerNode, len(nodes))
+	copy(sorted, nodes)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Children[index] == nil || sorted[j].Children[index] == nil {
+			return false
+		}
+		return sorted[i].Children[index].Version < sorted[j].Children[index].Version
+	})
+	return sorted
+}
+
+// mergeInnerNodes merges a set of inner nodes into a single inner node. The
+// nodes must all be of the same height. The resulting node is written to the
+// provided tree writer. The resulting node is returned.
 func mergeInnerNodes( // nolint: funlen // needs refactor
 	ctx context.Context,
 	pt TreeWriter,
 	dest TreeReader,
 	destID *nodestore.NodeID,
 	nodes []*nodestore.InnerNode,
-	trees []TreeReader,
+	trees []*MemTree,
 ) (nodestore.Node, error) {
 	conflicts := []int{}
 	node := nodes[0]
@@ -169,7 +256,6 @@ func mergeInnerNodes( // nolint: funlen // needs refactor
 			}
 		}
 	}
-
 	// Create a new merged child in the location of each conflict
 	var destInnerNode *nodestore.InnerNode
 	var ok bool
@@ -180,19 +266,17 @@ func mergeInnerNodes( // nolint: funlen // needs refactor
 		}
 		destInnerNode, ok = destNode.(*nodestore.InnerNode)
 		if !ok {
-			return nil, newUnexpectedNodeError(nodestore.Inner, destNode)
+			return nil, NewUnexpectedNodeError(nodestore.Inner, destNode)
 		}
 	}
-
 	newInner := nodestore.NewInnerNode(node.Height, node.Start, node.End, len(node.Children))
 	if destInnerNode != nil {
 		newInner.Children = destInnerNode.Children
 	}
 	for _, conflict := range conflicts {
 		conflictedNodes := make([]nodestore.NodeID, 0, len(trees))
-		conflictedTrees := make([]TreeReader, 0, len(trees))
+		conflictedTrees := make([]*MemTree, 0, len(trees))
 		statistics := map[string]*nodestore.Statistics{}
-		maxVersion := uint64(0)
 		var destChild *nodestore.NodeID
 		var destChildVersion *uint64
 		if destInnerNode != nil && destInnerNode.Children[conflict] != nil {
@@ -203,13 +287,25 @@ func mergeInnerNodes( // nolint: funlen // needs refactor
 			destChild = &child.ID
 			destChildVersion = &child.Version
 		}
-		for i, node := range nodes {
+		// Sort nodes by version of the conflicted child, if it exists.
+		// This is necessary to ensure that the highest version is used.
+		sortedNodes := sortByChildVersion(nodes, conflict)
+		maxVersion := uint64(0)
+		for i, node := range sortedNodes {
 			child := node.Children[conflict]
 			if child == nil {
 				continue
 			}
 			if child.Version > maxVersion {
 				maxVersion = child.Version
+			}
+			// If the child is marked as deleted, ignore all versions up to, and including that, child.
+			// TODO: reconcile statistics for tombstoned children.
+			if (child.ID == nodestore.NodeID{}) {
+				clear(conflictedNodes)
+				clear(conflictedTrees)
+				clear(statistics)
+				continue
 			}
 			conflictedNodes = append(conflictedNodes, child.ID)
 			conflictedTrees = append(conflictedTrees, trees[i])
@@ -223,9 +319,13 @@ func mergeInnerNodes( // nolint: funlen // needs refactor
 				}
 			}
 		}
-		merged, err := mergeLevel(ctx, pt, dest, destChild, destChildVersion, conflictedNodes, conflictedTrees)
-		if err != nil {
-			return nil, err
+		merged := nodestore.NodeID{}
+		var err error
+		if len(conflictedNodes) > 0 {
+			merged, err = mergeLevel(ctx, pt, dest, destChild, destChildVersion, conflictedNodes, conflictedTrees)
+			if err != nil {
+				return nil, err
+			}
 		}
 		newInner.Children[conflict] = &nodestore.Child{
 			ID:         merged,
@@ -236,6 +336,9 @@ func mergeInnerNodes( // nolint: funlen // needs refactor
 	return newInner, nil
 }
 
+// mergeLevel merges the nodes provided into a single node of the same type. The
+// nodes must all be of the same type. The resulting node is written to the
+// provided tree writer. The resulting node is returned.
 func mergeLevel(
 	ctx context.Context,
 	mt TreeWriter,
@@ -243,7 +346,7 @@ func mergeLevel(
 	destID *nodestore.NodeID,
 	destVersion *uint64,
 	ids []nodestore.NodeID,
-	trees []TreeReader,
+	trees []*MemTree,
 ) (nodeID nodestore.NodeID, err error) {
 	if len(ids) == 0 {
 		return nodeID, errors.New("no nodes to merge")
@@ -287,9 +390,18 @@ func mergeLevel(
 	return id, nil
 }
 
-func Merge(ctx context.Context, output *MemTree, dest TreeReader, trees ...TreeReader) error {
+// Merge merges the trees provided into the output tree. The output tree is
+// expected to be empty. The trees are merged in the order they are provided.
+// The trees must all have the same height. The output tree will have the same
+// height as the input trees.
+func Merge(
+	ctx context.Context,
+	dest TreeReader,
+	trees ...*MemTree,
+) (*MemTree, error) {
+	output := NewMemTree(nodestore.RandomNodeID(), nil)
 	if len(trees) == 0 {
-		return errors.New("no trees to merge")
+		return nil, errors.New("no trees to merge")
 	}
 	destRoot := dest.Root()
 	ids := make([]nodestore.NodeID, 0, len(trees))
@@ -298,26 +410,26 @@ func Merge(ctx context.Context, output *MemTree, dest TreeReader, trees ...TreeR
 		id := tree.Root()
 		root, err := tree.Get(ctx, id)
 		if err != nil {
-			return fmt.Errorf("failed to get root: %w", err)
+			return nil, fmt.Errorf("failed to get root: %w", err)
 		}
 		innerNode, ok := root.(*nodestore.InnerNode)
 		if !ok {
-			return newUnexpectedNodeError(nodestore.Inner, root)
+			return nil, NewUnexpectedNodeError(nodestore.Inner, root)
 		}
 		roots = append(roots, innerNode)
 		ids = append(ids, id)
 	}
 	for _, root := range roots {
 		if root.Height != roots[0].Height {
-			return MismatchedHeightsError{root.Height, roots[0].Height}
+			return nil, MismatchedHeightsError{root.Height, roots[0].Height}
 		}
 	}
 	mergedRoot, err := mergeLevel(ctx, output, dest, &destRoot, nil, ids, trees)
 	if err != nil {
-		return fmt.Errorf("failed to merge: %w", err)
+		return nil, fmt.Errorf("failed to merge: %w", err)
 	}
 	output.SetRoot(mergedRoot)
-	return nil
+	return output, nil
 }
 
 // mergeLeaves merges a set of leaf nodes into a single leaf node. Data is
@@ -333,7 +445,7 @@ func mergeLeaves(
 	if len(leaves) == 1 {
 		leaf, ok := leaves[0].(*nodestore.LeafNode)
 		if !ok {
-			return nil, newUnexpectedNodeError(nodestore.Leaf, leaf)
+			return nil, NewUnexpectedNodeError(nodestore.Leaf, leaf)
 		}
 		data, err := io.ReadAll(leaf.Data())
 		if err != nil {
@@ -345,7 +457,7 @@ func mergeLeaves(
 	for i, leaf := range leaves {
 		leaf, ok := leaf.(*nodestore.LeafNode)
 		if !ok {
-			return nil, newUnexpectedNodeError(nodestore.Leaf, leaf)
+			return nil, NewUnexpectedNodeError(nodestore.Leaf, leaf)
 		}
 		reader, err := mcap.NewReader(leaf.Data())
 		if err != nil {
@@ -364,7 +476,7 @@ func mergeLeaves(
 	return nodestore.NewLeafNode(buf.Bytes(), ancestorNodeID, ancestorVersion), nil
 }
 
-// // bwidth returns the width of each bucket in seconds.
+// bwidth returns the width of each bucket in seconds.
 func bwidth(n *nodestore.InnerNode) uint64 {
 	bwidth := (n.End - n.Start) / uint64(len(n.Children))
 	return bwidth


### PR DESCRIPTION
Added initial implementation of (+ tests for) `DeleteMessagesInRange`, which constructs a partial tree that represents the deletion of messages in the given range.
- Tombstones are placed in the tree at the location of children that are fully contained within the range. The partial tree, consisting of all nodes on the path to deletion (excluding the deleted nodes themselves, which have been tombstoned in their parents' children arrays), is returned.
- TODO: add support for statistics reconciliation (currently nil'd on the path to deletion).

Refactored `Merge`, `Insert`, and `MergeInserts` methods to return a memtree. `Insert` and `Merge` no longer take in a `*MemTree` to write their output to. An empty memtree is created within these methods and used for writing.

Cleaned up method docstrings.

Made `NewUnexpectedNodeError` public.
