### PR TITLE
Ensure local disk directory store does atomic put

### DIFF
--- a/client/dp3/cmd/server.go
+++ b/client/dp3/cmd/server.go
@@ -70,7 +70,11 @@ var serverCmd = &cobra.Command{
 			}
 			store = storage.NewS3Store(mc, serverS3Bucket)
 		} else {
-			store = storage.NewDirectoryStore(serverDataDir)
+			var err error
+			store, err = storage.NewDirectoryStore(serverDataDir)
+			if err != nil {
+				bailf("error creating directory store: %s", err)
+			}
 		}
 		opts := []service.DP3Option{
 			service.WithPort(serverPort),

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -21,6 +21,9 @@ func TestStorageProviders(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
+	dstore, err := storage.NewDirectoryStore(tmpdir)
+	require.NoError(t, err)
+
 	cases := []struct {
 		assertion string
 		store     storage.Provider
@@ -35,7 +38,7 @@ func TestStorageProviders(t *testing.T) {
 		},
 		{
 			"directory store",
-			storage.NewDirectoryStore(tmpdir),
+			dstore,
 		},
 	}
 


### PR DESCRIPTION
Prior to this commit, the directory storage provider did a write straight to final storage, which would result in a partial file if interrupted. Now we write to a tmpfile and do an atomic rename to the final location.

On initialization of a directory store, the root directory is walked and any orphaned tmpfiles are deleted.