### PR TITLE
Add support for precise range-based deletions

### DIFF
--- a/mcap/concat_iterator.go
+++ b/mcap/concat_iterator.go
@@ -1,0 +1,53 @@
+package mcap
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/foxglove/mcap/go/mcap"
+)
+
+/*
+A concat iterator returns the concatenation of multiple iterators. It is up to
+the caller to ensure that the inputs are in the correct order and
+nonoverlapping.
+*/
+
+//////////////////////////////////////////////////////////////////////////////
+
+type concatIterator struct {
+	iterators []mcap.MessageIterator
+	idx       int
+	rsc       io.ReadSeekCloser
+}
+
+// Next returns the next message in the iterator.
+func (ci *concatIterator) Next(buf []byte) (*mcap.Schema, *mcap.Channel, *mcap.Message, error) {
+	if ci.idx >= len(ci.iterators) {
+		return nil, nil, nil, io.EOF
+	}
+	schema, channel, message, err := ci.iterators[ci.idx].Next(buf)
+	if err == nil {
+		return schema, channel, message, nil
+	}
+	if errors.Is(err, io.EOF) {
+		_, err := ci.rsc.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to seek to reader start: %w", err)
+		}
+		ci.idx++
+		return ci.Next(buf)
+	}
+	return nil, nil, nil, fmt.Errorf("failed to read next message: %w", err)
+}
+
+// NewConcatIterator returns a new MessageIterator that concatenates the messages
+// from the given ranges.
+func NewConcatIterator(rsc io.ReadSeekCloser, ranges [][]uint64) mcap.MessageIterator {
+	iterators := make([]mcap.MessageIterator, 0, len(ranges))
+	for _, r := range ranges {
+		iterators = append(iterators, NewLazyIndexedIterator(rsc, r[0], r[1]))
+	}
+	return &concatIterator{rsc: rsc, iterators: iterators}
+}

--- a/mcap/lazy_indexed_iterator.go
+++ b/mcap/lazy_indexed_iterator.go
@@ -1,0 +1,61 @@
+package mcap
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/foxglove/mcap/go/mcap"
+)
+
+/*
+The MCAP message iterator requires an instantiated mcap.Reader, and
+instantiating the Reader does IO to verify the magic number. When we build an
+execution tree of iterators we don't want to do any IO until the first call to
+next, to avoid having more than the necessary number of file descriptors open at
+once. So this iterator wraps the mcap reader with lazy initialization.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+
+type lazyIndexedIterator struct {
+	it    mcap.MessageIterator
+	rsc   io.ReadSeekCloser
+	start uint64
+	end   uint64
+
+	initialized bool
+}
+
+func (it *lazyIndexedIterator) initialize() error {
+	reader, err := NewReader(it.rsc)
+	if err != nil {
+		return fmt.Errorf("failed to create reader: %w", err)
+	}
+	iterator, err := reader.Messages(mcap.AfterNanos(it.start), mcap.BeforeNanos(it.end))
+	if err != nil {
+		return fmt.Errorf("failed to create message iterator: %w", err)
+	}
+	it.it = iterator
+	it.initialized = true
+	return nil
+}
+
+// Next returns the next message in the iterator.
+func (it *lazyIndexedIterator) Next(_ []byte) (*mcap.Schema, *mcap.Channel, *mcap.Message, error) {
+	if !it.initialized {
+		if err := it.initialize(); err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to initialize iterator: %w", err)
+		}
+	}
+	s, c, m, err := it.it.Next(nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get next message: %w", err)
+	}
+	return s, c, m, nil
+}
+
+// NewLazyIndexedIterator returns an MCAP message iterator that is not
+// initialized (doing IO) until the first call to Next.
+func NewLazyIndexedIterator(rsc io.ReadSeekCloser, start uint64, end uint64) mcap.MessageIterator {
+	return &lazyIndexedIterator{rsc: rsc, start: start, end: end}
+}

--- a/nodestore/inner_node.go
+++ b/nodestore/inner_node.go
@@ -42,6 +42,11 @@ type Child struct {
 	Statistics map[string]*Statistics `json:"statistics"`
 }
 
+// IsTombstone returns true if the child is a tombstone.
+func (c *Child) IsTombstone() bool {
+	return c.ID == NodeID{} && c.Version > 0
+}
+
 // Size returns the size of the node in bytes.
 func (n *InnerNode) Size() uint64 {
 	return 8 + 8 + 1 + uint64(len(n.Children)*24)

--- a/nodestore/leaf_node.go
+++ b/nodestore/leaf_node.go
@@ -57,6 +57,7 @@ func (n *LeafNode) AncestorDeleted() bool {
 	return n.ancestorDeleteEnd > 0
 }
 
+// AncestorDeleteStart returns the start of the ancestor deletion range.
 func (n *LeafNode) AncestorDeleteStart() uint64 {
 	return n.ancestorDeleteStart
 }

--- a/nodestore/leaf_node.go
+++ b/nodestore/leaf_node.go
@@ -70,8 +70,6 @@ func (n *LeafNode) AncestorDeleteEnd() uint64 {
 // FromBytes deserializes the node from a byte slice.
 func (n *LeafNode) FromBytes(data []byte) error {
 	var version uint8
-	var ancestorDeleted bool
-	var ancestorVersion, ancestorDeleteStart, ancestorDeleteEnd uint64
 	offset := util.ReadU8(data, &version)
 	if version < 128 {
 		return errors.New("not a leaf node")
@@ -79,9 +77,9 @@ func (n *LeafNode) FromBytes(data []byte) error {
 	n.leafNodeVersion = version - 128
 
 	offset += copy(n.ancestor[:], data[offset:])
-	offset += util.ReadU64(data[offset:], &ancestorVersion)
-	offset += util.ReadU64(data[offset:], &ancestorDeleteStart)
-	offset += util.ReadU64(data[offset:], &ancestorDeleteEnd)
+	offset += util.ReadU64(data[offset:], &n.ancestorVersion)
+	offset += util.ReadU64(data[offset:], &n.ancestorDeleteStart)
+	offset += util.ReadU64(data[offset:], &n.ancestorDeleteEnd)
 	n.data = data[offset:]
 	return nil
 }
@@ -109,6 +107,11 @@ func (n *LeafNode) Type() NodeType {
 // Ancestor returns the ID of the ancestor node.
 func (n *LeafNode) Ancestor() NodeID {
 	return n.ancestor
+}
+
+// HasAncestor returns true if the node has an ancestor.
+func (n *LeafNode) HasAncestor() bool {
+	return n.ancestor != NodeID{}
 }
 
 // AncestorVersion returns the version of the ancestor node.

--- a/nodestore/leaf_node.go
+++ b/nodestore/leaf_node.go
@@ -57,7 +57,6 @@ func (n *LeafNode) AncestorDeleted() bool {
 	return n.ancestorDeleteEnd > 0
 }
 
-// AncestorDeleteStart returns the start of the ancestor deletion range.
 func (n *LeafNode) AncestorDeleteStart() uint64 {
 	return n.ancestorDeleteStart
 }

--- a/nodestore/leaf_node_test.go
+++ b/nodestore/leaf_node_test.go
@@ -15,8 +15,10 @@ import (
 func leafNodeBytes(buf []byte) []byte {
 	return testutils.Flatten(
 		[]byte{1 + 128},
-		testutils.U64b(0),
 		make([]byte, 24),
+		testutils.U64b(0),
+		testutils.U64b(0),
+		testutils.U64b(0),
 		buf,
 	)
 }

--- a/nodestore/nodestore.go
+++ b/nodestore/nodestore.go
@@ -112,11 +112,11 @@ func (n *Nodestore) GetLeafData(ctx context.Context, prefix string, id NodeID) (
 		}
 		return ancestor, nil, fmt.Errorf("failed to get node %s: %w", id, err)
 	}
-	buf := make([]byte, 1+8+24)
+	buf := make([]byte, leafHeaderLength)
 	if _, err := io.ReadFull(reader, buf); err != nil {
 		return ancestor, nil, fmt.Errorf("failed to read leaf node: %w", err)
 	}
-	ancestor = NodeID(buf[1+8:])
+	ancestor = NodeID(buf[1+1 : 1+1+24])
 	return ancestor, reader, nil
 }
 

--- a/routes/delete.go
+++ b/routes/delete.go
@@ -1,0 +1,34 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wkalt/dp3/treemgr"
+	"github.com/wkalt/dp3/util/httputil"
+	"github.com/wkalt/dp3/util/log"
+)
+
+type DeleteRequest struct {
+	ProducerID string `json:"producerId"`
+	Topic      string `json:"topic"`
+	Start      uint64 `json:"start"`
+	End        uint64 `json:"end"`
+}
+
+func newDeleteHandler(tmgr *treemgr.TreeManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		req := DeleteRequest{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httputil.BadRequest(ctx, w, "error decoding request: %s", err)
+			return
+		}
+		defer r.Body.Close()
+		ctx = log.AddTags(ctx, "producer", req.ProducerID, "topic", req.Topic)
+		if err := tmgr.DeleteMessages(ctx, req.ProducerID, req.Topic, req.Start, req.End); err != nil {
+			httputil.InternalServerError(ctx, w, "error deleting: %s", err)
+			return
+		}
+	}
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -36,5 +36,6 @@ func MakeRoutes(tmgr *treemgr.TreeManager) *mux.Router {
 	r.HandleFunc("/export", newExportHandler(tmgr)).Methods("POST")
 	r.HandleFunc("/query", newQueryHandler(tmgr)).Methods("POST")
 	r.HandleFunc("/statrange", newStatRangeHandler(tmgr)).Methods("POST")
+	r.HandleFunc("/delete", newDeleteHandler(tmgr)).Methods("POST")
 	return r
 }

--- a/tree/byo.go
+++ b/tree/byo.go
@@ -29,21 +29,20 @@ func (t *byoTreeReader) Get(ctx context.Context, id nodestore.NodeID) (nodestore
 	return t.get(ctx, t.prefix, id)
 }
 
-// GetLeafData returns the data for a leaf node.
-func (t *byoTreeReader) GetLeafData(ctx context.Context, id nodestore.NodeID) (
-	nodestore.NodeID, io.ReadSeekCloser, error,
+// GetLeafNode returns the data for a leaf node.
+func (t *byoTreeReader) GetLeafNode(ctx context.Context, id nodestore.NodeID) (
+	*nodestore.LeafNode, io.ReadSeekCloser, error,
 ) {
-	var ancestor nodestore.NodeID
 	node, err := t.get(ctx, t.prefix, id)
 	if err != nil {
-		return ancestor, nil, err
+		return nil, nil, err
 	}
 
 	leaf, ok := node.(*nodestore.LeafNode)
 	if !ok {
-		return ancestor, nil, NewUnexpectedNodeError(nodestore.Leaf, node)
+		return nil, nil, NewUnexpectedNodeError(nodestore.Leaf, node)
 	}
-	return leaf.Ancestor(), util.NewReadSeekNopCloser(leaf.Data()), nil
+	return leaf, util.NewReadSeekNopCloser(leaf.Data()), nil
 }
 
 // NewBYOTreeReader creates a new BYOTreeReader.

--- a/tree/bytetree.go
+++ b/tree/bytetree.go
@@ -47,9 +47,12 @@ func (b *byteTree) Get(ctx context.Context, id nodestore.NodeID) (nodestore.Node
 		return nil, fmt.Errorf("failed to seek to offset: %w", err)
 	}
 	buf := make([]byte, length)
-	_, err = io.ReadFull(b.r, buf)
+	n, err := io.ReadFull(b.r, buf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read node data: %w", err)
+	}
+	if n < 1 {
+		return nil, errors.New("node data is empty")
 	}
 	if isLeaf(buf) {
 		node := nodestore.NewLeafNode(nil, nil, nil)

--- a/tree/iterator.go
+++ b/tree/iterator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 
 	fmcap "github.com/foxglove/mcap/go/mcap"
 	"github.com/wkalt/dp3/mcap"
@@ -23,8 +24,7 @@ type Iterator struct {
 	start uint64
 	end   uint64
 
-	readers     []*fmcap.Reader
-	closers     []io.Closer
+	readclosers []io.ReadSeekCloser
 	msgIterator fmcap.MessageIterator
 	tr          TreeReader
 	minVersion  uint64
@@ -52,15 +52,15 @@ func (ti *Iterator) Close() error {
 
 // More returns true if there are more elements in the iteration.
 func (ti *Iterator) More() bool {
-	return len(ti.readers) > 0 || len(ti.stack) > 0
+	return len(ti.readclosers) > 0 || len(ti.stack) > 0
 }
 
 func (ti *Iterator) closeActiveReaders() error {
-	for _, reader := range ti.readers {
+	for _, reader := range ti.readclosers {
 		reader.Close()
 	}
-	errs := make([]error, 0, len(ti.closers))
-	for _, closer := range ti.closers {
+	errs := make([]error, 0, len(ti.readclosers))
+	for _, closer := range ti.readclosers {
 		if err := closer.Close(); err != nil {
 			errs = append(errs, err)
 		}
@@ -77,8 +77,7 @@ func (ti *Iterator) advance(ctx context.Context) error {
 	if err := ti.closeActiveReaders(); err != nil {
 		return fmt.Errorf("failed to close leaf reader: %w", err)
 	}
-	ti.readers = nil
-	ti.closers = nil
+	ti.readclosers = nil
 	ti.msgIterator = nil
 	if err := ti.openNextLeaf(ctx); err != nil {
 		return fmt.Errorf("failed to open next leaf: %w", err)
@@ -142,51 +141,66 @@ func (ti *Iterator) getNextLeaf(ctx context.Context) (nodeID nodestore.NodeID, e
 	return nodeID, io.EOF
 }
 
-func (ti *Iterator) openLeaf(ctx context.Context, nodeID nodestore.NodeID) (
-	*nodestore.LeafNode, fmcap.MessageIterator, error,
-) {
-	// problem: we need a bit more info out of here, but we don't want to return
-	// a massive resultset. It would be better if this could give us a
-	// partly-populated leaf node with the rsc. Since the current solution is a
-	// hack maybe a little more hack can't hurt...
-	node, rsc, err := ti.tr.GetLeafNode(ctx, nodeID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get reader: %w", err)
-	}
-	reader, err := mcap.NewReader(rsc)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create reader: %w", err)
-	}
-	it, err := reader.Messages(fmcap.AfterNanos(ti.start), fmcap.BeforeNanos(ti.end))
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create message iterator: %w", err)
-	}
-	ti.readers = append(ti.readers, reader)
-	ti.closers = append(ti.closers, rsc)
-	return node, it, nil
-}
-
-// openNextLeaf opens the next leaf in the iterator.
+// openNextLeaf opens the next iterator to scan. A leaf may be a single node, or
+// it may be the tail of a linked list, pointing backward at one or more
+// ancestor nodes. This occurs either when new data is inserted over an existing
+// leaf, or when data from a leaf is deleted. We need to take care to ensure we
+// handle both situations correctly, and also efficiently.
+//
+//	Example: w(1, 5) -> w(6, 10) -> d(4, 8) ->  w(7, 15)
+//
+// 1. Create a [][][]uint64
+// 2. Traverse all the way back to the start of the list
+// 3. Add the first element: {{{1, 5}}}
+// 4. Add the second element: {{{1, 5}}, {{6, 10}}}
+// 5. Split previous ranges, possibly subdividing them: {{{1, 4}}, {{8, 10}}}
+// 6. Add a new element: {{{1, 4}}, {{8, 10}}, {{7, 15}}}. Merge these.
 func (ti *Iterator) openNextLeaf(ctx context.Context) error {
 	leafID, err := ti.getNextLeaf(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get next leaf: %w", err)
 	}
 	// merge iterator of mcap iterators, or just the singleton.
-	leafNode, it, err := ti.openLeaf(ctx, leafID)
+	nodes := []*nodestore.LeafNode{}
+	readers := []io.ReadSeekCloser{}
+
+	leaf, rsc, err := ti.tr.GetLeafNode(ctx, leafID)
 	if err != nil {
-		return fmt.Errorf("failed to open leaf: %w", err)
+		return fmt.Errorf("failed to get leaf: %w", err)
 	}
-	iterators := []fmcap.MessageIterator{it}
-	ancestor := leafNode.Ancestor()
+	nodes = append(nodes, leaf)
+	readers = append(readers, rsc)
+
+	ancestor := leaf.Ancestor()
 	for (ancestor != nodestore.NodeID{}) {
-		leafNode, it, err = ti.openLeaf(ctx, ancestor)
+		leaf, rsc, err := ti.tr.GetLeafNode(ctx, ancestor)
 		if err != nil {
 			return fmt.Errorf("failed to get ancestor: %w", err)
 		}
-		iterators = append(iterators, it)
-		ancestor = leafNode.Ancestor()
+		nodes = append(nodes, leaf)
+		readers = append(readers, rsc)
+		ancestor = leaf.Ancestor()
 	}
+	// now we have the full list of ancestors, and readers, in reverse
+	// chronological order. Most likely (technically up to the storage
+	// implementation) no IO has been performed. Now go forward through the list
+	// to figure out what time ranges we need to grab from each element.
+	slices.Reverse(nodes)
+	slices.Reverse(readers)
+	rangesets := [][][]uint64{}
+	for _, leaf := range nodes {
+		if leaf.AncestorDeleted() {
+			for i, rangeset := range rangesets {
+				rangesets[i] = SplitRangeSet(rangeset, leaf.AncestorDeleteStart(), leaf.AncestorDeleteEnd())
+			}
+		}
+		rangesets = append(rangesets, [][]uint64{{ti.start, ti.end}})
+	}
+	iterators := make([]fmcap.MessageIterator, len(rangesets))
+	for i := range rangesets {
+		iterators[i] = mcap.NewConcatIterator(readers[i], rangesets[i])
+	}
+	ti.readclosers = readers
 	if len(iterators) == 1 {
 		ti.msgIterator = iterators[0]
 	} else {
@@ -196,4 +210,21 @@ func (ti *Iterator) openNextLeaf(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func SplitRangeSet(rangeset [][]uint64, left uint64, right uint64) [][]uint64 {
+	newRangeset := [][]uint64{}
+	for _, r := range rangeset {
+		if r[1] < left || r[0] > right {
+			newRangeset = append(newRangeset, r)
+			continue
+		}
+		if r[0] < left {
+			newRangeset = append(newRangeset, []uint64{r[0], left})
+		}
+		if r[1] > right {
+			newRangeset = append(newRangeset, []uint64{right, r[1]})
+		}
+	}
+	return newRangeset
 }

--- a/tree/iterator_test.go
+++ b/tree/iterator_test.go
@@ -28,7 +28,6 @@ func TestTreeIterator(t *testing.T) {
 			[][]int64{{100}},
 			1,
 		},
-
 		{
 			"three messages",
 			[][]int64{{100, 1000, 10000}},
@@ -52,6 +51,39 @@ func TestTreeIterator(t *testing.T) {
 			}
 			require.Equal(t, c.expectedMessageCount, count)
 			require.NoError(t, it.Close())
+		})
+	}
+}
+
+func TestSplitRangeSet(t *testing.T) {
+	cases := []struct {
+		assertion string
+		input     [][]uint64
+		split     []uint64
+		expected  [][]uint64
+	}{
+		{
+			"split on left side",
+			[][]uint64{{10, 20}},
+			[]uint64{0, 15},
+			[][]uint64{{15, 20}},
+		},
+		{
+			"split on right side",
+			[][]uint64{{10, 20}},
+			[]uint64{15, 25},
+			[][]uint64{{10, 15}},
+		},
+		{
+			"split in the middle",
+			[][]uint64{{10, 20}},
+			[]uint64{15, 17},
+			[][]uint64{{10, 15}, {17, 20}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			require.Equal(t, c.expected, tree.SplitRangeSet(c.input, c.split[0], c.split[1]))
 		})
 	}
 }

--- a/tree/memtree.go
+++ b/tree/memtree.go
@@ -36,20 +36,19 @@ func (m *MemTree) Get(ctx context.Context, id nodestore.NodeID) (nodestore.Node,
 	return node, nil
 }
 
-// GetLeafData returns the data for a leaf node.
-func (m *MemTree) GetLeafData(
+// GetLeafNode returns the data for a leaf node.
+func (m *MemTree) GetLeafNode(
 	ctx context.Context, id nodestore.NodeID,
-) (nodestore.NodeID, io.ReadSeekCloser, error) {
-	var ancestor nodestore.NodeID
+) (*nodestore.LeafNode, io.ReadSeekCloser, error) {
 	node, err := m.Get(ctx, id)
 	if err != nil {
-		return ancestor, nil, err
+		return nil, nil, err
 	}
 	leaf, ok := node.(*nodestore.LeafNode)
 	if !ok {
-		return ancestor, nil, errors.New("node is not a leaf")
+		return nil, nil, errors.New("node is not a leaf")
 	}
-	return leaf.Ancestor(), util.NewReadSeekNopCloser(leaf.Data()), nil
+	return leaf, util.NewReadSeekNopCloser(leaf.Data()), nil
 }
 
 // Put inserts a node into the MemTree.

--- a/tree/memtree.go
+++ b/tree/memtree.go
@@ -87,6 +87,9 @@ func (m *MemTree) FromBytes(ctx context.Context, data []byte) error {
 				if child == nil {
 					continue
 				}
+				if child.IsTombstone() {
+					continue
+				}
 				ids = append(ids, child.ID)
 			}
 		}

--- a/tree/memtree_test.go
+++ b/tree/memtree_test.go
@@ -54,7 +54,7 @@ func TestMemtreeSerialization(t *testing.T) {
 			data := &bytes.Buffer{}
 			mcap.WriteFile(t, data, []int64{ts})
 			schema := tree.GetSchema(t, bytes.NewReader(data.Bytes()))
-			schemaHash := util.CryptoHash(schema.Data)
+			schemaHash := util.CryptographicHash(schema.Data)
 			stats := map[string]*nodestore.Statistics{
 				schemaHash: {MessageCount: 1},
 			}

--- a/tree/testutils.go
+++ b/tree/testutils.go
@@ -44,7 +44,7 @@ func MergeInserts(
 		buf := &bytes.Buffer{}
 		mcap.WriteFile(t, buf, batch)
 		schema := GetSchema(t, bytes.NewReader(buf.Bytes()))
-		hash := util.CryptoHash(schema.Data)
+		hash := util.CryptographicHash(schema.Data)
 		stats := map[string]*nodestore.Statistics{
 			hash: {
 				MessageCount:    int64(len(batch)),

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -20,6 +20,26 @@ return new root IDs.
 
 The storage of dp3 consists of many trees, which are coordinated by the treemgr
 module.
+
+Note on integer overflows:
+It is not difficult to construct a tree that spans into the future range of time
+where uint64 nanoseconds will overflow, in 2554. While the inner nodes of that
+tree, which are denominated in seconds, are fine, any math operations on those
+boundaries or the computed boundaries of their children that involve multiplying
+by 1e9 will cause a problem.
+
+The guards against overflow are not as strong as they could be, but the way
+things are currently written is that in the cases where we compute child
+boundaries using nanosecond conversion, we always check first if there is a
+child in the corresponding slot to begin, and skip over the child if so. By that
+we are assured that any data that would cause an overflow was already written
+into the tree somehow. Since the tree input is itself denominated in nanoseconds
+and then cast down to seconds, there is no way to "write an overflowed timestamp
+to the tree" -- whatever overflowed uint64 we get is just a uint64 from our
+perspective.
+
+I believe this all means that as long as you avoid computing start/end bounds of
+children that do not exist, your code is safe from overflows.
 */
 
 // //////////////////////////////////////////////////////////////////////////////
@@ -101,87 +121,83 @@ func Insert(
 // path to deletion (excluding the deleted nodes themselves, which have been
 // tombstoned in their parents' children arrays), is returned.
 //
-// As before, the root is merely used as a template for determining the structure
-// of the partial tree.
+// When a deletion range intersects a leaf node but does not fully cover it, the
+// node is partially deleted. Since the deletion method does no IO with the
+// existing tree, it has no way of knowing in this case whether there is data
+// already existing in that location. We record an empty leaf node with a
+// "delete range" set to the part of the node that should be deleted. During the
+// merge step, there are then two cases to consider: either there was previously
+// some data in that location, or there was not.
 //
-// TODO: add support for statistics reconciliation (currently nil'd on the
-// path to deletion).
+// If the location previously had leaf data, we add to the new leaf's Ancestor
+// field the node ID of the previous leaf in the same location. On read, the
+// tree iterator is responsible for navigating these linked lists and
+// merging/skipping data as appropriate.
+//
+// If the location previously had no leaf data, the overlay is dropped in the
+// merge step resulting in no new leaves to the tree.
+//
+// The root argument is merely used as a template for determining the structure
+// of the partial tree -- no storage IO is performed in this function.
 func DeleteMessagesInRange(
-	ctx context.Context,
-	root *nodestore.InnerNode,
-	version uint64,
-	start uint64,
-	end uint64,
+	ctx context.Context, oldroot *nodestore.InnerNode, version uint64, start uint64, end uint64,
 ) (*MemTree, error) {
-	if root == nil {
-		return nil, errors.New("root is nil")
-	}
-	tw := NewMemTree(nodestore.RandomNodeID(), root)
 	if start >= end {
 		return nil, fmt.Errorf("invalid range: start %d cannot be >= end %d", start, end)
 	}
-	if start >= root.End*1e9 || end < root.Start*1e9 {
-		return nil, fmt.Errorf("range [%d, %d) out of bounds [%d, %d)", start, end, root.Start*1e9, root.End*1e9)
+	if start >= oldroot.End*1e9 || end < oldroot.Start*1e9 {
+		return nil, fmt.Errorf("range [%d, %d) out of bounds [%d, %d)", start, end, oldroot.Start*1e9, oldroot.End*1e9)
 	}
-	clonedRoot := nodestore.NewInnerNode(root.Height, root.Start, root.End, len(root.Children))
-	clonedRootID := nodestore.RandomNodeID()
-	if err := tw.Put(ctx, clonedRootID, clonedRoot); err != nil {
-		return nil, fmt.Errorf("failed to store new root: %w", err)
-	}
-	stack := []*nodestore.InnerNode{clonedRoot}
+	root := nodestore.NewInnerNode(oldroot.Height, oldroot.Start, oldroot.End, len(oldroot.Children))
+	tw := NewMemTree(nodestore.RandomNodeID(), root)
+	stack := []*nodestore.InnerNode{root}
+	leafData := &bytes.Buffer{}
 	for len(stack) > 0 {
 		node := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
-		// The node is partially within the range, i.e. either the start or end
-		// of the range is within the node. Descend into only the appropriate children.
-		// for i, child := range node.Children {
-		for i := range len(node.Children) {
+		for i := range node.Children {
 			childStart := node.Start + bwidth(node)*uint64(i)
 			childEnd := node.Start + bwidth(node)*uint64(i+1)
+			// The child is entirely outside the range.
 			if start >= childEnd*1e9 || end <= childStart*1e9 {
-				// The child is entirely outside the range.
 				continue
 			}
-			if start <= childStart*1e9 && end >= childEnd*1e9 { // TODO: check bounds
-				// The entire child is within the range.
+			// The entire child is within the range.
+			if start <= childStart*1e9 && end >= childEnd*1e9 {
 				node.PlaceTombstoneChild(uint64(i), version)
 				continue
 			}
-
+			// Start, end, or both intersect the child. Treat both same as start.
 			if node.Height > 1 {
-				clonedChild := nodestore.NewInnerNode(node.Height-1, childStart, childEnd, len(node.Children))
-				clonedChildID := nodestore.RandomNodeID()
-				if err := tw.Put(ctx, clonedChildID, clonedChild); err != nil {
+				newChild := nodestore.NewInnerNode(node.Height-1, childStart, childEnd, len(node.Children))
+				newChildID := nodestore.RandomNodeID()
+				if err := tw.Put(ctx, newChildID, newChild); err != nil {
 					return nil, fmt.Errorf("failed to store new inner node: %w", err)
 				}
-				bucket := bucket(start, node)
-				node.PlaceChild(bucket, clonedChildID, version, nil)
-				stack = append(stack, clonedChild)
+				if childStart*1e9 <= start && start < childEnd*1e9 {
+					node.PlaceChild(bucket(start, node), newChildID, version, nil)
+				} else {
+					node.PlaceChild(bucket(end, node), newChildID, version, nil)
+				}
+				stack = append(stack, newChild)
 				continue
 			}
-
-			// If we make it to this part, we are deleting part of a child. The
-			// child's bounds overlap with (start, end), but (start, end) are
-			// not necessarily within the child. We create an empty new child
-			// linked back to the previous ancestor, with a deletion range set
-			// equal to max(start, childStart) and min(end, childEnd).
-			rangeStart := max(start, childStart*1e9)
-			rangeEnd := min(end, childEnd*1e9)
-			bucket := bucket(rangeStart, node)
-			leafData := &bytes.Buffer{}
+			// One level above the leaf node, deleting partial leaf.
+			deleteRangeStart := max(start, childStart*1e9)
+			deleteRangeEnd := min(end, childEnd*1e9)
 			if err := writeEmptyMCAP(leafData); err != nil {
 				return nil, fmt.Errorf("failed to write empty MCAP: %w", err)
 			}
-			newLeafID := nodestore.RandomNodeID()
-			newLeaf := nodestore.NewLeafNode(leafData.Bytes(), nil, nil) // NB: filled in on merge.
-			newLeaf.DeleteRange(rangeStart, rangeEnd)
-			if err := tw.Put(ctx, newLeafID, newLeaf); err != nil {
+			leafID := nodestore.RandomNodeID()
+			leaf := nodestore.NewLeafNode(leafData.Bytes(), nil, nil)
+			leaf.DeleteRange(deleteRangeStart, deleteRangeEnd)
+			if err := tw.Put(ctx, leafID, leaf); err != nil {
 				return nil, fmt.Errorf("failed to store new leaf node: %w", err)
 			}
-			node.PlaceChild(bucket, newLeafID, version, nil)
+			node.PlaceChild(bucket(deleteRangeStart, node), leafID, version, nil)
+			leafData.Reset()
 		}
 	}
-	tw.SetRoot(clonedRootID)
 	return tw, nil
 }
 
@@ -339,21 +355,21 @@ func mergeInnerNodes( // nolint: funlen // needs refactor
 				}
 			}
 		}
-		merged := nodestore.NodeID{}
-		var err error
 		if len(conflictedNodes) > 0 {
-			merged, err = mergeLevel(ctx, pt, dest, destChild, destChildVersion, conflictedNodes, conflictedTrees)
+			merged, err := mergeLevel(ctx, pt, dest, destChild, destChildVersion, conflictedNodes, conflictedTrees)
 			if err != nil {
 				if errors.Is(err, errElideNode) {
 					continue
 				}
 				return nil, err
 			}
-		}
-		newInner.Children[conflict] = &nodestore.Child{
-			ID:         merged,
-			Version:    maxVersion,
-			Statistics: statistics,
+			newInner.Children[conflict] = &nodestore.Child{
+				ID:         merged,
+				Version:    maxVersion,
+				Statistics: statistics,
+			}
+		} else {
+			newInner.Children[conflict] = nil
 		}
 	}
 	return newInner, nil
@@ -457,6 +473,29 @@ func Merge(
 
 var errElideNode = errors.New("elide node")
 
+func mergeOneLeaf(
+	ancestorNodeID *nodestore.NodeID,
+	ancestorVersion *uint64,
+	leaf *nodestore.LeafNode,
+) (nodestore.Node, error) {
+	data, err := io.ReadAll(leaf.Data())
+	if err != nil {
+		return nil, fmt.Errorf("failed to read data: %w", err)
+	}
+	newLeaf := nodestore.NewLeafNode(data, ancestorNodeID, ancestorVersion)
+	if leaf.AncestorDeleted() {
+		// if we have an ancestor deleted here, but we have no ancestor node ID,
+		// then we are dealing with a deletion that spans unpopulated data. In
+		// this scenario we don't want to create a leaf node in the merged
+		// output.
+		if ancestorNodeID == nil {
+			return nil, errElideNode
+		}
+		newLeaf.DeleteRange(leaf.AncestorDeleteStart(), leaf.AncestorDeleteEnd())
+	}
+	return newLeaf, nil
+}
+
 // mergeLeaves merges a set of leaf nodes into a single leaf node. Data is
 // merged in timestamp order.
 func mergeLeaves(
@@ -472,24 +511,9 @@ func mergeLeaves(
 		if !ok {
 			return nil, NewUnexpectedNodeError(nodestore.Leaf, leaf)
 		}
-		data, err := io.ReadAll(leaf.Data())
-		if err != nil {
-			return nil, fmt.Errorf("failed to read data: %w", err)
-		}
-
-		newLeaf := nodestore.NewLeafNode(data, ancestorNodeID, ancestorVersion)
-		if leaf.AncestorDeleted() {
-			// if we have an ancestor deleted here, but we have no ancestor node ID,
-			// then we are dealing with a deletion that spans unpopulated data. In
-			// this scenario we don't want to create a leaf node in the merged
-			// output.
-			if ancestorNodeID == nil {
-				return nil, errElideNode
-			}
-			newLeaf.DeleteRange(leaf.AncestorDeleteStart(), leaf.AncestorDeleteEnd())
-		}
-		return newLeaf, nil
+		return mergeOneLeaf(ancestorNodeID, ancestorVersion, leaf)
 	}
+
 	iterators := make([]fmcap.MessageIterator, len(leaves))
 	for i, leaf := range leaves {
 		leaf, ok := leaf.(*nodestore.LeafNode)

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -29,11 +29,6 @@ func TestTreeErrors(t *testing.T) {
 		require.ErrorIs(t, err, tree.OutOfBoundsError{})
 	})
 
-	t.Run("deleting from a non-existent root", func(t *testing.T) {
-		_, err := tree.DeleteMessagesInRange(ctx, nil, 0, 0, 1000*1e9)
-		require.Error(t, err)
-	})
-
 	t.Run("out of bounds delete", func(t *testing.T) {
 		rootStart, rootEnd := uint64(0), uint64(4096)
 		start, end := uint64(10000*1e9), uint64(10001*1e9)
@@ -206,86 +201,85 @@ func TestDeleteMessagesInRange(t *testing.T) {
 		prep      [][]int64
 		start     uint64
 		end       uint64
-		expected  string
+
+		partialResult string
+		mergedResult  string
 	}{
 		{
 			"delete from empty tree inserts tombstones even where no data existed",
 			1,
 			[][]int64{},
 			0,
-			8e9,
+			8,
 			"[0-16 [<del> 0-4:1] [<del> 4-8:1]]",
+			"[0-16]",
 		},
 		{
 			"delete from single insert",
 			1,
 			[][]int64{{6}},
-			4e9,
-			8e9,
+			4,
+			8,
 			"[0-16 [<del> 4-8:2]]",
+			"[0-16]",
 		},
 		{
-			"delete one among two inserts",
+			"delete one of two inserts",
 			1,
 			[][]int64{{3}, {7}},
 			0,
-			4e9,
-			"[0-16 [<del> 0-4:3] [<ref> 4-8:2 (1b count=1) [leaf 1 msg]]]",
+			4,
+			"[0-16 [<del> 0-4:3]]",
+			"[0-16 [<ref> 4-8:2 (1b count=1) [leaf 1 msg]]]",
 		},
 		{
-			"delete one among three inserts",
+			"delete middle leaf of three inserts results in a hole",
 			1,
 			[][]int64{{3}, {7}, {11}},
-			4e9,
-			8e9,
-			`[0-16
-			  [<ref> 0-4:1 (1b count=1) [leaf 1 msg]]
-			  [<del> 4-8:4]
-			  [<ref> 8-12:3 (1b count=1) [leaf 1 msg]]]`,
+			4,
+			8,
+			`[0-16 [<del> 4-8:4]]`,
+			`[0-16 [<ref> 0-4:1 (1b count=1) [leaf 1 msg]] [<ref> 8-12:3 (1b count=1) [leaf 1 msg]]]`,
 		},
 		{
 			"delete root node (should delete links to all immediate descendants)",
 			1,
 			[][]int64{{4}},
 			0,
-			16e9,
+			16,
 			`[0-16
 			  [<del> 0-4:2]
 			  [<del> 4-8:2]
 			  [<del> 8-12:2]
 			  [<del> 12-16:2]]`,
+			`[0-16]`,
 		},
 		{
 			"delete leaf node in a depth-2 tree",
 			2,
 			[][]int64{{7}, {11}},
-			4e9,
-			8e9,
-			`[0-64
-			  [0-16:3 (1b count=2)
-			    [<del> 4-8:3]
-				[<ref> 8-12:2 (1b count=1) [leaf 1 msg]]]]`,
+			4,
+			8,
+			`[0-64 [0-16:3 () [<del> 4-8:3]]]`,
+			`[0-64 [0-16:3 (1b count=2) [<ref> 8-12:2 (1b count=1) [leaf 1 msg]]]]`,
 		},
 		{
 			"delete depth-1 inner node in a depth-2 tree",
 			2,
 			[][]int64{{7}, {20}},
-			0e9,
-			16e9,
-			`[0-64
-			  [<del> 0-16:3]
-			  [<ref> 16-32:2 (1b count=1)
-			   [<ref> 20-24:2 (1b count=1) [leaf 1 msg]]]]`,
+			0,
+			16,
+			`[0-64 [<del> 0-16:3]]`,
+			`[0-64 [<ref> 16-32:2 (1b count=1) [<ref> 20-24:2 (1b count=1) [leaf 1 msg]]]]`,
 		},
 		{
 			"delete that partially clears a populated leaf",
 			1,
 			[][]int64{{3}, {7}},
 			0,
-			3e9,
-			`[0-16
-			  [0-4:3 (1b count=1) [leaf 0 msgs]-<del 0-3>->[leaf 1 msg]]
-			  [<ref> 4-8:2 (1b count=1) [leaf 1 msg]]]`,
+			3,
+			`[0-16 [0-4:3 () [leaf 0 msgs]-<del 0 3>-> ??]]`,
+			`[0-16 [0-4:3 (1b count=1) [leaf 0 msgs]-<del 0-3>->[leaf 1 msg]] [<ref> 4-8:2 (1b count=1) [leaf 1 msg]]]`,
 		},
 		{
 			"delete that partially clears an unpopulated leaf - results in no new empty node",
@@ -293,9 +287,8 @@ func TestDeleteMessagesInRange(t *testing.T) {
 			[][]int64{{3}, {7}},
 			0,
 			11e9,
-			`[0-16
-			  [<del> 0-4:3]
-			  [<del> 4-8:3]]`,
+			`[0-16 [<del> 0-4:3] [<del> 4-8:3] [<del> 8-12:3] [<del> 12-16:3]]`,
+			`[0-16]`,
 		},
 	}
 	for _, c := range cases {
@@ -304,27 +297,24 @@ func TestDeleteMessagesInRange(t *testing.T) {
 			setup := tree.MergeInserts(
 				ctx, t, 0, util.Pow(uint64(4), int(c.height+1)), c.height, 4, c.prep,
 			)
-			tmpRoot := nodestore.NewInnerNode(c.height, 0, util.Pow(uint64(4), int(c.height+1)), 4)
 
-			start, err := tree.Print(ctx, setup)
-			require.NoError(t, err)
-			fmt.Println(start)
 			// Construct a partial tree with the deletes
+			tmpRoot := nodestore.NewInnerNode(c.height, 0, util.Pow(uint64(4), int(c.height+1)), 4)
 			version := len(c.prep) + 1
-			partial, err := tree.DeleteMessagesInRange(ctx, tmpRoot, uint64(version), c.start, c.end)
+			partial, err := tree.DeleteMessagesInRange(ctx, tmpRoot, uint64(version), c.start*1e9, c.end*1e9)
 			require.NoError(t, err)
 
-			partstr, err := tree.Print(ctx, partial)
+			repr, err := tree.Print(ctx, partial, setup)
 			require.NoError(t, err)
-			fmt.Println("partial", partstr)
+			assertEqualTrees(t, c.partialResult, repr)
 
 			// Merge the two trees, setup and partial
 			final, err := tree.Merge(ctx, setup, partial)
 			require.NoError(t, err)
 			// Print the tree to compare with expected output
-			repr, err := tree.Print(ctx, final, setup)
+			repr, err = tree.Print(ctx, final, setup)
 			require.NoError(t, err)
-			assertEqualTrees(t, c.expected, repr)
+			assertEqualTrees(t, c.mergedResult, repr)
 		})
 	}
 }

--- a/tree/treereader.go
+++ b/tree/treereader.go
@@ -23,7 +23,7 @@ type TreeReader interface {
 	Root() nodestore.NodeID
 	Get(ctx context.Context, id nodestore.NodeID) (nodestore.Node, error)
 	// todo: remove this in favor of a closure on leaf nodes.
-	GetLeafData(ctx context.Context, id nodestore.NodeID) (nodestore.NodeID, io.ReadSeekCloser, error)
+	GetLeafNode(ctx context.Context, id nodestore.NodeID) (*nodestore.LeafNode, io.ReadSeekCloser, error)
 }
 
 func getNode(

--- a/treemgr/treemgr_test.go
+++ b/treemgr/treemgr_test.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 
+	fmcap "github.com/foxglove/mcap/go/mcap"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 	"github.com/wkalt/dp3/mcap"
@@ -353,6 +355,119 @@ func TestReceiveDifferentSchemas(t *testing.T) {
 		str := tmgr.PrintStream(ctx, "my-device", "topic-0")
 		assertEqualTrees(t, expected, str)
 	})
+}
+
+func runSequence(ctx context.Context, t *testing.T, tmgr *treemgr.TreeManager, s string) string {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	for len(s) > 0 {
+		buf.Reset()
+		switch s[0] {
+		case ' ':
+			s = s[1:]
+			continue
+		case 'w': // w(10, 100)
+			nums := strings.Split(s[2:strings.Index(s, ")")], ",")
+			left, err := strconv.ParseInt(nums[0], 10, 64)
+			require.NoError(t, err)
+			right, err := strconv.ParseInt(nums[1], 10, 64)
+			require.NoError(t, err)
+			mcap.WriteFile(t, buf, [][]int64{{1e9 * left, 1e9 * right}}...)
+			require.NoError(t, tmgr.Receive(ctx, "my-device", buf))
+		case 'd':
+			nums := strings.Split(s[2:strings.Index(s, ")")], ",")
+			left, err := strconv.ParseInt(nums[0], 10, 64)
+			require.NoError(t, err)
+			right, err := strconv.ParseInt(nums[1], 10, 64)
+			require.NoError(t, err)
+			mcap.WriteFile(t, buf, [][]int64{{left}, {right}}...)
+			require.NoError(t, tmgr.DeleteMessages(ctx, "my-device", "topic-0", 1e9*uint64(left), 1e9*uint64(right)))
+		default:
+			require.Fail(t, "unknown command")
+		}
+		require.NoError(t, tmgr.ForceFlush(ctx))
+		s = s[strings.Index(s, ")")+1:]
+	}
+	return tmgr.PrintStream(ctx, "my-device", "topic-0")
+}
+
+func TestDeletionCases(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		assertion string
+		input     string
+		messages  []uint64
+	}{
+		{
+			"single topic file, single message",
+			"w(10,50)",
+			[]uint64{10e9, 50e9},
+		},
+		{
+			"write followed by a partial delete",
+			"w(10,50) d(40,70)",
+			[]uint64{10e9},
+		},
+		{
+			"write delete write",
+			"w(10,50) d(40,70) w(60,100)",
+			[]uint64{10e9, 60e9, 100e9},
+		},
+		{
+			"write, delete, write, delete",
+			"w(10,50) d(40,70) w(60,100) d(90,120)",
+			[]uint64{10e9, 60e9},
+		},
+		{
+			"write, delete, delete",
+			"w(10,50) d(5,20) d(40,60)",
+			[]uint64{},
+		},
+		{
+			"delete from middle of a range",
+			"w(10,20) w(30,40) w(60,80) d(15,35)",
+			[]uint64{10e9, 40e9, 60e9, 80e9},
+		},
+		{
+			"delete spanning multiple pages",
+			"w(10,20) w(30,40) w(60,80) d(15,65)",
+			[]uint64{10e9, 80e9},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			tmgr, finish := treemgr.TestTreeManager(ctx, t)
+			defer finish()
+			runSequence(ctx, t, tmgr, c.input)
+
+			output := &bytes.Buffer{}
+			roots, err := tmgr.GetLatestRoots(ctx, "my-device", map[string]uint64{"topic-0": 0})
+			require.NoError(t, err)
+
+			require.NoError(t, tmgr.GetMessages(ctx, output, 0, ^uint64(0), roots))
+
+			reader, err := mcap.NewReader(bytes.NewReader(output.Bytes()))
+			require.NoError(t, err)
+
+			info, err := reader.Info()
+			require.NoError(t, err)
+			require.Equal(t, len(c.messages), int(info.Statistics.MessageCount))
+
+			messages := []uint64{}
+			it, err := reader.Messages(fmcap.InOrder(fmcap.LogTimeOrder))
+			require.NoError(t, err)
+			for {
+				_, _, message, err := it.Next(nil)
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				require.NoError(t, err)
+				messages = append(messages, message.LogTime)
+			}
+			require.Equal(t, c.messages, messages)
+		})
+	}
 }
 
 func TestReceive(t *testing.T) {

--- a/treemgr/writer.go
+++ b/treemgr/writer.go
@@ -145,7 +145,7 @@ func (w *writer) initialize(ts uint64) (err error) {
 		w.parsers[schema.ID] = parser
 		fields := ros1msg.AnalyzeSchema(*msgdef)
 		w.schemaStats[schema.ID] = nodestore.NewStatistics(fields)
-		w.schemaHashes[schema.ID] = util.CryptoHash(schema.Data)
+		w.schemaHashes[schema.ID] = util.CryptographicHash(schema.Data)
 	}
 	for _, channel := range w.channels {
 		if err := w.w.WriteChannel(channel); err != nil {

--- a/util/encoding.go
+++ b/util/encoding.go
@@ -27,6 +27,15 @@ func ReadU64(src []byte, x *uint64) int {
 	return 8
 }
 
+func ReadBool(src []byte, x *bool) int {
+	if src[0] == 1 {
+		*x = true
+	} else {
+		*x = false
+	}
+	return 1
+}
+
 // ReadPrefixedString reads a string from data and stores it in s, returning the
 // written length.
 func ReadPrefixedString(data []byte, s *string) int {
@@ -57,6 +66,16 @@ func U32(dst []byte, src uint32) int {
 func U64(dst []byte, src uint64) int {
 	binary.LittleEndian.PutUint64(dst, src)
 	return 8
+}
+
+// Bool writes a bool to dst and returns the written length.
+func Bool(dst []byte, src bool) int {
+	if src {
+		dst[0] = 1
+	} else {
+		dst[0] = 0
+	}
+	return 1
 }
 
 // WritePrefixedString writes a string to buf and returns the written length.

--- a/util/testutils/testutils.go
+++ b/util/testutils/testutils.go
@@ -46,6 +46,14 @@ func U16b(v uint16) []byte {
 	return buf
 }
 
+func Bool(v bool) []byte {
+	if v {
+		return U8b(1)
+	}
+	return U8b(0)
+
+}
+
 // U32b returns a byte slice containing a single uint32 value.
 func U32b(v uint32) []byte {
 	buf := make([]byte, 4)

--- a/util/testutils/testutils.go
+++ b/util/testutils/testutils.go
@@ -46,12 +46,12 @@ func U16b(v uint16) []byte {
 	return buf
 }
 
+// Bool returns a byte slice containing a single boolean value.
 func Bool(v bool) []byte {
 	if v {
 		return U8b(1)
 	}
 	return U8b(0)
-
 }
 
 // U32b returns a byte slice containing a single uint32 value.

--- a/util/utils.go
+++ b/util/utils.go
@@ -124,9 +124,9 @@ func Min[T cmp.Ordered](a, b T) T {
 	return b
 }
 
-// CryptoHash returns a stable hex-encoded cryptographic hash for use in the
+// CryptographicHash returns a stable hex-encoded cryptographic hash for use in the
 // project.
-func CryptoHash(data []byte) string {
+func CryptographicHash(data []byte) string {
 	h := sha256.New()
 	h.Write(data)
 	return hex.EncodeToString(h.Sum(nil))


### PR DESCRIPTION
This adds support for range-based deletions that partially intersect leaf nodes. Previously this was prohibited.

Partial deletions are handled through some new metadata on the leaf node structure (deletion start, deletion end) that indicate ranges in previous (linked) leaf nodes that readers should mask. The masking logic is implemented in the tree iterator.

Also adds client/HTTP route support for deletion.