### PR TITLE
Add `desc` keyword to reverse order of results

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -94,6 +94,7 @@ type ScanFactory func(
 	database string,
 	producer string,
 	table string,
+	descending bool,
 	start, end uint64,
 ) (*tree.Iterator, error)
 
@@ -129,7 +130,7 @@ func compileMergeJoin(ctx context.Context, node *plan.Node, sf ScanFactory) (Nod
 			return nil, err
 		}
 	}
-	return NewMergeNode(nodes...), nil
+	return NewMergeNode(node.Descending, nodes...), nil
 }
 
 func compileAsofJoin(ctx context.Context, node *plan.Node, sf ScanFactory) (Node, error) {
@@ -230,7 +231,7 @@ func compileScan(ctx context.Context, node *plan.Node, sf ScanFactory) (Node, er
 			return nil, fmt.Errorf("expected uint64 end time, got %T", node.Args[5])
 		}
 	}
-	it, err := sf(ctx, database, producer, table, start, end)
+	it, err := sf(ctx, database, producer, table, node.Descending, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -239,6 +240,5 @@ func compileScan(ctx context.Context, node *plan.Node, sf ScanFactory) (Node, er
 		expr := newExpression(util.When(alias != "", alias, table), node.Children[0])
 		return NewFilterNode(expr.filter, scan), nil
 	}
-
 	return scan, nil
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -42,6 +42,11 @@ func TestQueryExecution(t *testing.T) {
 				[]message{},
 			},
 			{
+				"basic descending scan",
+				"from device t0 desc;",
+				[]message{{"t0", 4}, {"t0", 3}, {"t0", 2}, {"t0", 1}, {"t0", 0}},
+			},
+			{
 				"basic merge join",
 				"from device t0, t1;",
 				[]message{

--- a/executor/merge_node.go
+++ b/executor/merge_node.go
@@ -38,12 +38,17 @@ type mergeNode struct {
 }
 
 // NewMergeNode returns a new merge node.
-func NewMergeNode(children ...Node) *mergeNode {
+// The descending parameter specifies the order in which tuples should be
+// popped from the priority queue.
+func NewMergeNode(descending bool, children ...Node) *mergeNode {
 	return &mergeNode{
 		children: children,
 		pq: util.NewPriorityQueue(func(a, b queueElement) bool {
 			if a.tuple.message.LogTime == b.tuple.message.LogTime {
 				return a.tuple.message.ChannelID < b.tuple.message.ChannelID
+			}
+			if descending {
+				return a.tuple.message.LogTime > b.tuple.message.LogTime
 			}
 			return a.tuple.message.LogTime < b.tuple.message.LogTime
 		}),

--- a/executor/merge_node_test.go
+++ b/executor/merge_node_test.go
@@ -12,19 +12,30 @@ import (
 func TestMergeNode(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {
-		assertion string
-		children  []executor.Node
-		expected  []uint64
+		assertion  string
+		descending bool
+		children   []executor.Node
+		expected   []uint64
 	}{
 		{
 			"single node",
+			false,
 			[]executor.Node{
 				executor.NewMockNode(1, 2, 3),
 			},
 			[]uint64{1, 2, 3},
 		},
 		{
+			"single node descending",
+			true,
+			[]executor.Node{
+				executor.NewMockNode(3, 2, 1),
+			},
+			[]uint64{3, 2, 1},
+		},
+		{
 			"two nodes",
+			false,
 			[]executor.Node{
 				executor.NewMockNode(1, 3, 5),
 				executor.NewMockNode(2, 4, 6),
@@ -32,7 +43,17 @@ func TestMergeNode(t *testing.T) {
 			[]uint64{1, 2, 3, 4, 5, 6},
 		},
 		{
+			"two nodes descending",
+			true,
+			[]executor.Node{
+				executor.NewMockNode(5, 3, 1),
+				executor.NewMockNode(6, 4, 2),
+			},
+			[]uint64{6, 5, 4, 3, 2, 1},
+		},
+		{
 			"three nodes",
+			false,
 			[]executor.Node{
 				executor.NewMockNode(1, 4, 7),
 				executor.NewMockNode(2, 5, 8),
@@ -42,6 +63,7 @@ func TestMergeNode(t *testing.T) {
 		},
 		{
 			"empty nodes",
+			false,
 			[]executor.Node{
 				executor.NewMockNode(),
 				executor.NewMockNode(),
@@ -51,6 +73,7 @@ func TestMergeNode(t *testing.T) {
 		},
 		{
 			"one nonempty node",
+			false,
 			[]executor.Node{
 				executor.NewMockNode(1, 2, 3),
 				executor.NewMockNode(),
@@ -62,7 +85,7 @@ func TestMergeNode(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
-			node := executor.NewMergeNode(c.children...)
+			node := executor.NewMergeNode(c.descending, c.children...)
 			actual := []uint64{}
 			for {
 				tuple, err := node.Next(ctx)

--- a/mcap/concat_iterator.go
+++ b/mcap/concat_iterator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/foxglove/mcap/go/mcap"
 )
@@ -44,10 +45,13 @@ func (ci *concatIterator) Next(buf []byte) (*mcap.Schema, *mcap.Channel, *mcap.M
 
 // NewConcatIterator returns a new MessageIterator that concatenates the messages
 // from the given ranges.
-func NewConcatIterator(rs io.ReadSeeker, ranges [][]uint64) mcap.MessageIterator {
+func NewConcatIterator(rs io.ReadSeeker, ranges [][]uint64, descending bool) mcap.MessageIterator {
 	iterators := make([]mcap.MessageIterator, 0, len(ranges))
+	if descending {
+		slices.Reverse(ranges)
+	}
 	for _, r := range ranges {
-		iterators = append(iterators, NewLazyIndexedIterator(rs, r[0], r[1]))
+		iterators = append(iterators, NewLazyIndexedIterator(rs, r[0], r[1], descending))
 	}
 	return &concatIterator{rs: rs, iterators: iterators}
 }

--- a/mcap/concat_iterator_test.go
+++ b/mcap/concat_iterator_test.go
@@ -47,7 +47,7 @@ func TestConcatIterator(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
-			iter := mcap.NewConcatIterator(bytes.NewReader(input.Bytes()), c.ranges)
+			iter := mcap.NewConcatIterator(bytes.NewReader(input.Bytes()), c.ranges, false)
 			var got []uint64
 			for {
 				_, _, m, err := iter.Next(nil)

--- a/mcap/merge_iterator.go
+++ b/mcap/merge_iterator.go
@@ -96,10 +96,13 @@ func (mi *mergeIterator) Next([]byte) (*mcap.Schema, *mcap.Channel, *mcap.Messag
 	return s2, c2, m2, nil
 }
 
-func NmergeIterator(iterators ...mcap.MessageIterator) (mcap.MessageIterator, error) {
-	pq := util.NewPriorityQueue[record](func(a, b record) bool {
+func NmergeIterator(descending bool, iterators ...mcap.MessageIterator) (mcap.MessageIterator, error) {
+	pq := util.NewPriorityQueue(func(a, b record) bool {
 		if a.message.LogTime == b.message.LogTime {
 			return a.message.ChannelID < b.message.ChannelID
+		}
+		if descending {
+			return a.message.LogTime > b.message.LogTime
 		}
 		return a.message.LogTime < b.message.LogTime
 	})

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -75,6 +75,11 @@ func TestCompileQuery(t *testing.T) {
 			"[scan (a db device all-time)]",
 		},
 		{
+			"descending scan",
+			"from device a desc;",
+			"[scan desc (a db device all-time)]",
+		},
+		{
 			"single scan with a where clause",
 			"from device a where a.foo = 10;",
 			"[scan (a db device all-time) [binexp [= a.foo 10]]]",
@@ -126,6 +131,13 @@ func TestCompileQuery(t *testing.T) {
 			"from device a where a.b = 1 limit 10;",
 			`[limit 10
 			  [scan (a db device all-time) [binexp [= a.b 1]]]]`,
+		},
+		{
+			"merge join with descending",
+			"from device a, b desc;",
+			`[merge desc 
+			  [scan desc (a db device all-time)]
+			  [scan desc (b db device all-time)]]`,
 		},
 		{
 			"merge join with where clause",

--- a/ql/grammar.go
+++ b/ql/grammar.go
@@ -40,6 +40,7 @@ type Query struct {
 	Between      *Between     `@@?`
 	Select       Select       `@@`
 	Where        *Expression  `("where" @@)*`
+	Descending   bool         `@"desc"?`
 	PagingClause []PagingTerm `@@*`
 	Terminator   string       `";"`
 }

--- a/tree/iterator_test.go
+++ b/tree/iterator_test.go
@@ -3,55 +3,71 @@ package tree_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"math"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wkalt/dp3/tree"
+	"github.com/wkalt/dp3/util"
 )
 
 func TestTreeIterator(t *testing.T) {
 	ctx := context.Background()
-
 	cases := []struct {
-		assertion            string
-		times                [][]int64
-		expectedMessageCount int
+		assertion     string
+		times         [][]int64
+		expectedTimes []uint64
 	}{
 		{
 			"empty tree",
 			[][]int64{},
-			0,
+			[]uint64{},
 		},
 		{
 			"one message",
 			[][]int64{{100}},
-			1,
+			[]uint64{100},
 		},
 		{
-			"three messages",
-			[][]int64{{100, 1000, 10000}},
-			3,
+			"multiple messages on the same leaf",
+			[][]int64{{16, 32, 48}},
+			[]uint64{16, 32, 48},
+		},
+		{
+			"multiple messages on the same leaf (separate writes)",
+			[][]int64{{0, 16}, {32, 48}, {20, 40}},
+			[]uint64{0, 16, 20, 32, 40, 48},
+		},
+		{
+			"multiple messages on different leaves",
+			[][]int64{{100}, {1000}, {2000}},
+			[]uint64{100, 1000, 2000},
 		},
 	}
-
 	for _, c := range cases {
-		t.Run(c.assertion, func(t *testing.T) {
-			tr := tree.MergeInserts(ctx, t, 0, 128*1e9, 2, 64, c.times)
-
-			it := tree.NewTreeIterator(ctx, tr, 0, 128*1e9, 0)
-			var count int
-			for {
-				_, _, _, err := it.Next(ctx)
-				if errors.Is(err, io.EOF) {
-					break
+		for _, descending := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s%v", c.assertion, util.When(descending, " descending", "")), func(t *testing.T) {
+				if descending {
+					slices.Reverse(c.expectedTimes)
 				}
-				require.NoError(t, err)
-				count += 1
-			}
-			require.Equal(t, c.expectedMessageCount, count)
-			require.NoError(t, it.Close())
-		})
+				actualTimes := []uint64{}
+				tr := tree.MergeInserts(ctx, t, 0, util.Pow(uint64(64), 3), 2, 64, c.times)
+				it := tree.NewTreeIterator(ctx, tr, descending, 0, math.MaxUint64, 0)
+				for {
+					_, _, message, err := it.Next(ctx)
+					if errors.Is(err, io.EOF) {
+						break
+					}
+					require.NoError(t, err)
+					actualTimes = append(actualTimes, message.LogTime)
+				}
+				require.NoError(t, it.Close())
+				require.Equal(t, c.expectedTimes, actualTimes)
+			})
+		}
 	}
 }
 

--- a/tree/testutils.go
+++ b/tree/testutils.go
@@ -26,7 +26,8 @@ func GetSchema(t *testing.T, r io.ReadSeeker) *fmcap.Schema {
 }
 
 // MergeInserts executes a list of inserts and then merges the resulting partial
-// trees into a single tree. Times are expected in seconds.
+// trees into a single tree. Times are expected in seconds. Each batch of times
+// is expected to land on a single leaf.
 func MergeInserts(
 	ctx context.Context,
 	t *testing.T,

--- a/treemgr/treemgr.go
+++ b/treemgr/treemgr.go
@@ -570,6 +570,7 @@ func (tm *TreeManager) NewTreeIterator(
 	database string,
 	producer string,
 	topic string,
+	descending bool,
 	start, end uint64,
 ) (*tree.Iterator, error) {
 	prefix, rootID, _, err := tm.rootmap.GetLatest(ctx, database, producer, topic)
@@ -577,7 +578,7 @@ func (tm *TreeManager) NewTreeIterator(
 		return nil, fmt.Errorf("failed to get latest root: %w", err)
 	}
 	tr := tree.NewBYOTreeReader(prefix, rootID, tm.ns.Get)
-	return tree.NewTreeIterator(ctx, tr, start, end, 0), nil
+	return tree.NewTreeIterator(ctx, tr, descending, start, end, 0), nil
 }
 
 func (tm *TreeManager) loadIterators(
@@ -593,7 +594,7 @@ func (tm *TreeManager) loadIterators(
 	for i, root := range roots {
 		g.Go(func() error {
 			tr := tree.NewBYOTreeReader(root.Prefix, root.NodeID, tm.ns.Get)
-			it := tree.NewTreeIterator(ctx, tr, start, end, root.RequestedMinVersion)
+			it := tree.NewTreeIterator(ctx, tr, false, start, end, root.RequestedMinVersion)
 			schema, channel, message, err := it.Next(ctx)
 			if err != nil {
 				if errors.Is(err, io.EOF) {


### PR DESCRIPTION
Adds the `desc` keyword to the grammar and the plan. The keyword is used to reverse the order of the results of a query.

The tree iterator is updated to support traversal in reverse order. `MergeNode` is also updated to support reverse time-ordered merging of streams, if the `desc` keyword is present in the query.