### PR TITLE
Support parenthetical groupings in the grammar

### DIFF
--- a/executor/filter_node.go
+++ b/executor/filter_node.go
@@ -21,16 +21,16 @@ type filterNode struct {
 // Next returns the next tuple from the node.
 func (n *filterNode) Next(ctx context.Context) (*tuple, error) {
 	for {
-		t, err := n.child.Next(ctx)
+		tup, err := n.child.Next(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read next message: %w", err)
 		}
-		ok, err := n.filter(t)
+		ok, err := n.filter(tup)
 		if err != nil {
 			return nil, fmt.Errorf("failed to filter message: %w", err)
 		}
 		if ok {
-			return t, nil
+			return tup, nil
 		}
 	}
 }

--- a/plan/errors.go
+++ b/plan/errors.go
@@ -1,0 +1,14 @@
+package plan
+
+type BadPlanError struct {
+	Err error
+}
+
+func (e BadPlanError) Error() string {
+	return e.Err.Error()
+}
+
+func (e BadPlanError) Is(target error) bool {
+	_, ok := target.(BadPlanError)
+	return ok
+}

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -9,6 +9,55 @@ import (
 	"github.com/wkalt/dp3/util/testutils"
 )
 
+// todo: it would be useful if we could distinguish between the cases where
+// multiple tables are referenced from the wrong part of the query, and when
+// aliases that are just invalid/inconsistent occur. The current tree traversal
+// isn't aware of other extant aliases (or tables) when it does its validation,
+// so this will require a bit more effort.
+func TestInvalidPlans(t *testing.T) {
+	cases := []struct {
+		assertion string
+		query     string
+		output    string
+	}{
+		{
+			"and expression spanning tables",
+			"from device a, b where a.foo = 10 and b.bar = 20",
+			"more than one alias",
+		},
+		{
+			"grouped or expression spanning tables",
+			"from device a, b where (a.foo = 10 or b.bar = 20)",
+			"more than one alias",
+		},
+		{
+			"multiple aliases to same table in one scan",
+			"from device a as b where a.foo = 10 and b.bar = 20",
+			"more than one alias",
+		},
+		{
+			"where clauses must be qualified",
+			"from device a where foo = 10",
+			"field foo must be qualified with a dot",
+		},
+		{
+			"partly unqualified where clause",
+			"from device a where a.foo = 10 and bar = 20",
+			"field bar must be qualified with a dot",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			parser := ql.NewParser()
+			ast, err := parser.ParseString("", c.query)
+			require.NoError(t, err)
+			_, err = plan.CompileQuery("db", *ast)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), c.output)
+		})
+	}
+}
+
 func TestCompileQuery(t *testing.T) {
 	cases := []struct {
 		assertion string
@@ -23,17 +72,17 @@ func TestCompileQuery(t *testing.T) {
 		{
 			"single scan with a where clause",
 			"from device a where a.foo = 10",
-			"[scan (a db device all-time) [or [and [binexp [= a.foo 10]]]]]",
+			"[scan (a db device all-time) [binexp [= a.foo 10]]]",
 		},
 		{
 			"single scan with multiple where clauses",
 			"from device a where a.foo = 10 and a.bar = 20",
-			"[scan (a db device all-time) [or [and [binexp [= a.foo 10]] [binexp [= a.bar 20]]]]]",
+			"[scan (a db device all-time) [and [binexp [= a.foo 10]] [binexp [= a.bar 20]]]]",
 		},
 		{
-			"single scan with multiple where clauses",
+			"single scan with or condition",
 			"from device a where a.foo = 10 or a.bar = 20",
-			"[scan (a db device all-time) [or [and [binexp [= a.foo 10]]] [and [binexp [= a.bar 20]]]]]",
+			"[scan (a db device all-time) [or [binexp [= a.foo 10]] [binexp [= a.bar 20]]]]",
 		},
 		{
 			"single scan with an alias",
@@ -43,58 +92,84 @@ func TestCompileQuery(t *testing.T) {
 		{
 			"aliased where clauses are resolved",
 			"from device a as b where b.foo = 1",
-			"[scan (a b db device all-time) [or [and [binexp [= b.foo 1]]]]]",
+			"[scan (a b db device all-time) [binexp [= b.foo 1]]]",
 		},
 		{
 			"multiple aliased where clauses are resolved",
-			"from device a as b, c as d where b.foo = 1 and d.bar = 2",
+			"from device a as b, c as d where b.foo = 1 or d.bar = 2",
 			`[merge
-			   [scan (a b db device all-time) [or [and [binexp [= b.foo 1]] [binexp [= d.bar 2]]]]]
-			   [scan (c d db device all-time) [or [and [binexp [= b.foo 1]] [binexp [= d.bar 2]]]]]]`,
+			   [scan (a b db device all-time) [binexp [= b.foo 1]]]
+			   [scan (c d db device all-time) [binexp [= d.bar 2]]]]`,
 		},
 		{
 			"basic mj",
 			"from device a, b",
-			"[merge [scan (a db device all-time)] [scan (b db device all-time)]]",
+			`[merge
+			  [scan (a db device all-time)]
+			  [scan (b db device all-time)]]`,
 		},
 		{
 			"ternary mj",
 			"from device a, b, c",
-			"[merge [scan (a db device all-time)] [scan (b db device all-time)] [scan (c db device all-time)]]",
-		},
-		{
-			"scan with where clause",
-			"from device a where a.b = 1",
-			"[scan (a db device all-time) [or [and [binexp [= a.b 1]]]]]",
+			`[merge
+			  [scan (a db device all-time)]
+			  [scan (b db device all-time)]
+			  [scan (c db device all-time)]]`,
 		},
 		{
 			"scan with where clause and limit",
 			"from device a where a.b = 1 limit 10",
-			"[limit 10 [scan (a db device all-time) [or [and [binexp [= a.b 1]]]]]]",
+			`[limit 10
+			  [scan (a db device all-time) [binexp [= a.b 1]]]]`,
 		},
 		{
 			"merge join with where clause",
-			"from device a, b where a.b = 10 and b.c = 20",
+			"from device a, b where a.b = 10 or b.c = 20",
 			`[merge
-			  [scan (a db device all-time) [or [and [binexp [= a.b 10]] [binexp [= b.c 20]]]]]
-			  [scan (b db device all-time) [or [and [binexp [= a.b 10]] [binexp [= b.c 20]]]]]]`,
+			  [scan (a db device all-time) [binexp [= a.b 10]]]
+			  [scan (b db device all-time) [binexp [= b.c 20]]]]`,
 		},
 		{
 			"asof join with where clause",
-			"from device a precedes b where b.c = 10 and a.b = 20",
+			"from device a precedes b where b.c = 10 or a.b = 20",
 			`[asof (precedes full)
-			   [scan (a db device all-time) [or [and [binexp [= b.c 10]] [binexp [= a.b 20]]]]]
-			   [scan (b db device all-time) [or [and [binexp [= b.c 10]] [binexp [= a.b 20]]]]]]`,
+			   [scan (a db device all-time) [binexp [= a.b 20]]]
+			   [scan (b db device all-time) [binexp [= b.c 10]]]]`,
 		},
 		{
 			"asof join with restriction",
 			"from device a precedes b by less than 5 seconds",
-			"[asof (precedes full seconds 5) [scan (a db device all-time)] [scan (b db device all-time)]]",
+			`[asof (precedes full seconds 5)
+			  [scan (a db device all-time)]
+			  [scan (b db device all-time)]]`,
 		},
 		{
 			"asof join with aliasing",
 			"from device a as foo precedes b as bar by less than 5 seconds",
-			"[asof (precedes full seconds 5) [scan (a foo db device all-time)] [scan (b bar db device all-time)]]",
+			`[asof (precedes full seconds 5)
+			  [scan (a foo db device all-time)]
+			  [scan (b bar db device all-time)]]`,
+		},
+		{
+			"trivial subexpressions are pulled up",
+			"from devices a where (a.foo = 10)",
+			`[scan (a db devices all-time)
+			  [binexp [= a.foo 10]]]`,
+		},
+		{
+			"grouped subexpressions on a single scan",
+			"from devices a where (a.foo = 10 or a.bar = 20) and a.baz = 30",
+			`[scan (a db devices all-time)
+			  [and
+			    [or [binexp [= a.foo 10]] [binexp [= a.bar 20]]]
+			    [binexp [= a.baz 30]]]]`,
+		},
+		{
+			"grouped subexpressions on multiple scans",
+			"from devices a, b where (a.foo = 10 or a.bar = 20) or b.baz = 30",
+			`[merge
+			  [scan (a db devices all-time) [or [binexp [= a.foo 10]] [binexp [= a.bar 20]]]]
+			  [scan (b db devices all-time) [binexp [= b.baz 30]]]]`,
 		},
 	}
 	parser := ql.NewParser()

--- a/routes/query.go
+++ b/routes/query.go
@@ -62,6 +62,10 @@ func newQueryHandler(tmgr *treemgr.TreeManager) http.HandlerFunc {
 		}
 		qp, err := plan.CompileQuery(req.Database, *ast)
 		if err != nil {
+			if errors.Is(err, plan.BadPlanError{}) {
+				httputil.BadRequest(ctx, w, err.Error())
+				return
+			}
 			httputil.InternalServerError(ctx, w, "error compiling query: %s", err)
 			return
 		}

--- a/service/dp3_test.go
+++ b/service/dp3_test.go
@@ -6,9 +6,11 @@ package service_test
 // 	store, err := storage.NewDirectoryStore("../data")
 // 	require.NoError(t, err)
 // 	opts := []service.DP3Option{
-// 		WithPort(8089),
-// 		WithCacheSizeMegabytes(4096),
-// 		WithStorageProvider(store),
+// 		service.WithPort(8089),
+// 		service.WithCacheSizeMegabytes(4096),
+// 		service.WithStorageProvider(store),
+// 		service.WithDatabasePath("../dp3.db"),
+// 		service.WithWALDir("../waldir"),
 // 	}
 // 	svc := service.NewDP3Service()
 // 	require.NoError(t, svc.Start(ctx, opts...))

--- a/service/options.go
+++ b/service/options.go
@@ -22,6 +22,8 @@ type DP3Options struct {
 	LogLevel        slog.Level
 	SyncWorkers     int
 	StorageProvider storage.Provider
+	DatabasePath    string
+	WALDir          string
 }
 
 // WithCacheSizeMegabytes sets the cache size in megabytes.
@@ -35,6 +37,20 @@ func WithCacheSizeMegabytes(size uint64) DP3Option {
 func WithSyncWorkers(workers int) DP3Option {
 	return func(opts *DP3Options) {
 		opts.SyncWorkers = workers
+	}
+}
+
+// WithWALDir sets the directory for the write-ahead log.
+func WithWALDir(dir string) DP3Option {
+	return func(opts *DP3Options) {
+		opts.WALDir = dir
+	}
+}
+
+// WithDatabasePath sets the path to the rootmap database.
+func WithDatabasePath(path string) DP3Option {
+	return func(opts *DP3Options) {
+		opts.DatabasePath = path
 	}
 }
 


### PR DESCRIPTION
This addresses some rough edges in the grammar through introduction of parenthetical groupings and adds some structural validation to the queries.

Previously the meaning of "and" was a little confused in certain queries, for instance this would parse:

from my-device /foo, /bar where /foo.a = 10 and /bar.b = 20;

The meaning of this is unclear - what does it mean for both "/foo.a" and "/bar.b" to have these values? Should they have them at the same nanosecond? That seems not too useful and should probably warrant some more explicit syntax.

If the same nanosecond isn't implied, then in this context "and" is the same as an "or".

With this commit we will reject the query above, and make the user instead write,

from my-device /foo, /bar where /foo.a = 10 or /bar.b = 20;

The where clause of the query is split into separate expression trees for each table that is referenced, and within each tree we ensure that all scans and binary expressions reference the same table - i.e that the tree does not cross tables. If table crossing occurs we error in the plan step.