### PR TITLE
Ensure inner node children in merge are fully cloned

### DIFF
--- a/nodestore/inner_node.go
+++ b/nodestore/inner_node.go
@@ -47,6 +47,15 @@ func (c *Child) IsTombstone() bool {
 	return c.ID == NodeID{} && c.Version > 0
 }
 
+func (c *Child) Clone() *Child {
+	clone := *c
+	clone.Statistics = make(map[string]*Statistics, len(c.Statistics))
+	for k, v := range c.Statistics {
+		clone.Statistics[k] = v.Clone()
+	}
+	return &clone
+}
+
 // Size returns the size of the node in bytes.
 func (n *InnerNode) Size() uint64 {
 	return 8 + 8 + 1 + uint64(len(n.Children)*24)
@@ -73,6 +82,17 @@ func (n *InnerNode) FromBytes(data []byte) error {
 		return fmt.Errorf("error unmarshalling inner node: %w", err)
 	}
 	return nil
+}
+
+func (n *InnerNode) Clone() *InnerNode {
+	clone := *n
+	clone.Children = make([]*Child, len(n.Children))
+	for i, child := range n.Children {
+		if child != nil {
+			clone.Children[i] = child.Clone()
+		}
+	}
+	return &clone
 }
 
 // PlaceChild sets the child at the given index to the given ID and version.

--- a/service/dp3.go
+++ b/service/dp3.go
@@ -34,8 +34,7 @@ const (
 	gigabyte = 1024 * 1024 * 1024
 )
 
-type DP3 struct {
-}
+type DP3 struct{}
 
 // NewDP3Service creates a new DP3 service.
 func NewDP3Service() *DP3 {

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -279,19 +279,17 @@ func mergeInnerNodes( // nolint: funlen // needs refactor
 	}
 	// Create a new merged child in the location of each conflict
 	var destInnerNode *nodestore.InnerNode
-	var ok bool
+	newInner := nodestore.NewInnerNode(node.Height, node.Start, node.End, len(node.Children))
 	if destID != nil {
 		destNode, err := dest.Get(ctx, *destID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get dest node: %w", err)
 		}
-		destInnerNode, ok = destNode.(*nodestore.InnerNode)
+		inner, ok := destNode.(*nodestore.InnerNode)
 		if !ok {
 			return nil, NewUnexpectedNodeError(nodestore.Inner, destNode)
 		}
-	}
-	newInner := nodestore.NewInnerNode(node.Height, node.Start, node.End, len(node.Children))
-	if destInnerNode != nil {
+		destInnerNode = inner.Clone()
 		newInner.Children = destInnerNode.Children
 	}
 	for _, conflict := range conflicts {
@@ -379,7 +377,7 @@ func mergeLevel(
 	if len(pairs) == 0 {
 		return nodeID, errors.New("no nodes to merge")
 	}
-	nodes := make([]nodestore.Node, 0, len(pairs)) // may include dest
+	nodes := make([]nodestore.Node, 0, len(pairs))
 	for _, pair := range pairs {
 		node, err := pair.Second.Get(ctx, pair.First)
 		if err != nil {

--- a/treemgr/treemgr.go
+++ b/treemgr/treemgr.go
@@ -600,7 +600,7 @@ func (tm *TreeManager) loadIterators(
 					ch <- util.NewPair[int, *tree.Iterator](i, nil)
 					return nil
 				}
-				return fmt.Errorf("failed to get next message: %w", err)
+				return fmt.Errorf("failed to get next message from root %s: %w", root.NodeID, err)
 			}
 			mtx.Lock()
 			heap.Push(pq, record{schema, channel, message, i})


### PR DESCRIPTION
Prior to this commit the merge method was not doing a deep clone of child arrays for roots obtained from the nodestore, when it constructed its temporary tree. This could lead to concurrent readers reading invalid data.