### PR TITLE
Add explain support

### DIFF
--- a/executor/asof_node.go
+++ b/executor/asof_node.go
@@ -39,10 +39,10 @@ type asofJoinNode struct {
 }
 
 // Close the node.
-func (n *asofJoinNode) Close() error {
+func (n *asofJoinNode) Close(ctx context.Context) error {
 	errs := make([]error, 0, len(n.children))
 	for _, child := range n.children {
-		if err := child.Close(); err != nil {
+		if err := child.Close(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/executor/asof_node_test.go
+++ b/executor/asof_node_test.go
@@ -56,7 +56,7 @@ func TestAsofJoinNode(t *testing.T) {
 				actual = append(actual, tuple.LogTime())
 			}
 			require.Equal(t, c.expected, actual)
-			require.NoError(t, node.Close())
+			require.NoError(t, node.Close(ctx))
 		})
 	}
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -124,7 +124,7 @@ func TestQueryExecution(t *testing.T) {
 				require.NoError(t, err)
 
 				buf := &bytes.Buffer{}
-				require.NoError(t, executor.Run(ctx, buf, qp, tmgr.NewTreeIterator))
+				require.NoError(t, executor.Run(ctx, buf, qp, tmgr.NewTreeIterator, false))
 
 				reader, err := mcap.NewReader(bytes.NewReader(buf.Bytes()))
 				require.NoError(t, err)

--- a/executor/filter_node.go
+++ b/executor/filter_node.go
@@ -36,8 +36,8 @@ func (n *filterNode) Next(ctx context.Context) (*tuple, error) {
 }
 
 // Close the node.
-func (n *filterNode) Close() error {
-	if err := n.child.Close(); err != nil {
+func (n *filterNode) Close(ctx context.Context) error {
+	if err := n.child.Close(ctx); err != nil {
 		return fmt.Errorf("failed to close filter node: %w", err)
 	}
 	return nil

--- a/executor/limit_node.go
+++ b/executor/limit_node.go
@@ -37,8 +37,8 @@ func (n *limitNode) Next(ctx context.Context) (*tuple, error) {
 }
 
 // Close the node.
-func (n *limitNode) Close() error {
-	if err := n.child.Close(); err != nil {
+func (n *limitNode) Close(ctx context.Context) error {
+	if err := n.child.Close(ctx); err != nil {
 		return fmt.Errorf("failed to close limit node: %w", err)
 	}
 	return nil

--- a/executor/merge_node.go
+++ b/executor/merge_node.go
@@ -107,10 +107,10 @@ func (n *mergeNode) Next(ctx context.Context) (*tuple, error) {
 }
 
 // Close the node.
-func (n *mergeNode) Close() error {
+func (n *mergeNode) Close(ctx context.Context) error {
 	errs := make([]error, 0, len(n.children))
 	for _, child := range n.children {
-		if err := child.Close(); err != nil {
+		if err := child.Close(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/executor/merge_node_test.go
+++ b/executor/merge_node_test.go
@@ -96,7 +96,7 @@ func TestMergeNode(t *testing.T) {
 				actual = append(actual, tuple.LogTime())
 			}
 			require.Equal(t, c.expected, actual)
-			require.NoError(t, node.Close())
+			require.NoError(t, node.Close(ctx))
 		})
 	}
 }

--- a/executor/mock_node.go
+++ b/executor/mock_node.go
@@ -36,7 +36,7 @@ func (n *mockNode) String() string {
 }
 
 // Close the node.
-func (n *mockNode) Close() error {
+func (n *mockNode) Close(ctx context.Context) error {
 	return nil
 }
 

--- a/executor/node.go
+++ b/executor/node.go
@@ -47,5 +47,5 @@ func newTuple(schema *fmcap.Schema, channel *fmcap.Channel, message *fmcap.Messa
 type Node interface {
 	Next(ctx context.Context) (*tuple, error)
 	String() string
-	Close() error
+	Close(ctx context.Context) error
 }

--- a/executor/nodestats.go
+++ b/executor/nodestats.go
@@ -1,0 +1,94 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/wkalt/dp3/util"
+)
+
+type nodestats struct {
+	bytesOut  int
+	tuplesOut int
+
+	startTime           time.Time
+	elapsedToFirstTuple time.Duration
+	elapsedToLastTuple  time.Duration
+
+	initialized bool
+
+	child Node
+
+	label string
+
+	lastTupleRecorded bool
+}
+
+func NewNodeStats(child Node, label string) *nodestats {
+	return &nodestats{
+		child: child,
+		label: label,
+	}
+}
+
+func (n *nodestats) Next(ctx context.Context) (*tuple, error) {
+	if !n.initialized {
+		n.StartTimer()
+		n.initialized = true
+	}
+	tup, err := n.child.Next(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			n.RecordLastTuple()
+		}
+		return tup, fmt.Errorf("failed to get next record: %w", err)
+	}
+	n.IncTuplesOut(1)
+	n.IncBytesOut(len(tup.message.Data))
+	return tup, nil
+}
+
+func (n *nodestats) String() string {
+	return n.child.String()
+}
+
+func (n *nodestats) Close(ctx context.Context) error {
+	if !n.lastTupleRecorded {
+		n.RecordLastTuple()
+	}
+	ctx, _ = util.WithChildContext(ctx, n.label)
+	util.SetContextValue(ctx, "bytes_out", float64(n.bytesOut))
+	util.SetContextValue(ctx, "tuples_out", float64(n.tuplesOut))
+	util.SetContextValue(
+		ctx, "elapsed_to_first_tuple", float64(n.elapsedToFirstTuple.Milliseconds()))
+	util.SetContextValue(
+		ctx, "elapsed_to_last_tuple", float64(n.elapsedToLastTuple.Milliseconds()))
+	if err := n.child.Close(ctx); err != nil {
+		return fmt.Errorf("failed to close child: %w", err)
+	}
+	return nil
+}
+
+func (n *nodestats) IncBytesOut(bytes int) {
+	n.bytesOut += bytes
+}
+
+func (n *nodestats) IncTuplesOut(tuples int) {
+	n.tuplesOut += tuples
+}
+
+func (n *nodestats) StartTimer() {
+	n.startTime = time.Now()
+}
+
+func (n *nodestats) RecordFirstTuple() {
+	n.elapsedToFirstTuple = time.Since(n.startTime)
+}
+
+func (n *nodestats) RecordLastTuple() {
+	n.elapsedToLastTuple = time.Since(n.startTime)
+	n.lastTupleRecorded = true
+}

--- a/executor/offset_node.go
+++ b/executor/offset_node.go
@@ -39,8 +39,8 @@ func (n *offsetNode) Next(ctx context.Context) (*tuple, error) {
 }
 
 // Close the node.
-func (n *offsetNode) Close() error {
-	if err := n.child.Close(); err != nil {
+func (n *offsetNode) Close(ctx context.Context) error {
+	if err := n.child.Close(ctx); err != nil {
 		return fmt.Errorf("failed to close offset node: %w", err)
 	}
 	return nil

--- a/executor/offset_node_test.go
+++ b/executor/offset_node_test.go
@@ -71,7 +71,7 @@ func TestOffsetNode(t *testing.T) {
 				actual = append(actual, tuple.LogTime())
 			}
 			require.Equal(t, c.expected, actual)
-			require.NoError(t, n.Close())
+			require.NoError(t, n.Close(ctx))
 		})
 	}
 }

--- a/executor/scan_node.go
+++ b/executor/scan_node.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/wkalt/dp3/tree"
+	"github.com/wkalt/dp3/util"
 )
 
 /*
@@ -39,7 +40,13 @@ func (n *scanNode) Next(ctx context.Context) (*tuple, error) {
 }
 
 // Close the node.
-func (n *scanNode) Close() error {
+func (n *scanNode) Close(ctx context.Context) error {
+	util.SetContextData(ctx, "topic", n.topic)
+
+	stats := n.it.Stats()
+	util.SetContextValue(ctx, "inner_nodes_excluded", float64(stats.InnerNodesFiltered))
+	util.SetContextValue(ctx, "inner_nodes_scanned", float64(stats.InnerNodesScanned))
+
 	if err := n.it.Close(); err != nil {
 		return fmt.Errorf("failed to close scan node: %w", err)
 	}

--- a/mcap/merge.go
+++ b/mcap/merge.go
@@ -65,6 +65,13 @@ func NewMergeCoordinator(w *mcap.Writer) *MergeCoordinator {
 	}
 }
 
+func (c *MergeCoordinator) WriteMetadata(metadata *mcap.Metadata) error {
+	if err := c.w.WriteMetadata(metadata); err != nil {
+		return fmt.Errorf("failed to write metadata: %w", err)
+	}
+	return nil
+}
+
 func (c *MergeCoordinator) Write(schema *mcap.Schema, channel *mcap.Channel, msg *mcap.Message) error {
 	schemaID, ok := c.schemas[schema]
 	if !ok {
@@ -119,6 +126,13 @@ func (c *MergeCoordinator) Write(schema *mcap.Schema, channel *mcap.Channel, msg
 	msg.ChannelID = chanID
 	if err := c.w.WriteMessage(msg); err != nil {
 		return fmt.Errorf("failed to write message: %w", err)
+	}
+	return nil
+}
+
+func (c *MergeCoordinator) Close() error {
+	if err := c.w.Close(); err != nil {
+		return fmt.Errorf("failed to close writer: %w", err)
 	}
 	return nil
 }

--- a/ql/grammar.go
+++ b/ql/grammar.go
@@ -36,6 +36,7 @@ var (
 
 // Query represents a query in the dp3 query language.
 type Query struct {
+	Explain      bool         `@"explain"?`
 	From         string       `"from" @Word`
 	Between      *Between     `@@?`
 	Select       Select       `@@`

--- a/ql/grammar_test.go
+++ b/ql/grammar_test.go
@@ -480,23 +480,29 @@ func TestQuery(t *testing.T) {
 	}{
 		{
 			"simple",
+			"explain from my-robot a;",
+			newQuery(true, nil, newSelect("a", "", nil, nil), nil, false, nil),
+		},
+		{
+			"simple",
 			"from my-robot a;",
-			newQuery(nil, newSelect("a", "", nil, nil), nil, false, nil),
+			newQuery(false, nil, newSelect("a", "", nil, nil), nil, false, nil),
 		},
 		{
 			"with between",
 			`from my-robot between "a" and "b" a;`,
-			newQuery(newBetween("a", "b"), newSelect("a", "", nil, nil), nil, false, nil),
+			newQuery(false, newBetween("a", "b"), newSelect("a", "", nil, nil), nil, false, nil),
 		},
 		{
 			"with descending",
 			"from my-robot a desc;",
-			newQuery(nil, newSelect("a", "", nil, nil), nil, true, nil),
+			newQuery(false, nil, newSelect("a", "", nil, nil), nil, true, nil),
 		},
 		{
 			"with where",
 			"from my-robot a where a = 10;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", nil, nil),
 				newExpression(
@@ -510,6 +516,7 @@ func TestQuery(t *testing.T) {
 			"with where and paging",
 			"from my-robot a where a = 10 limit 10 offset 10;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", nil, nil),
 				newExpression(
@@ -524,6 +531,7 @@ func TestQuery(t *testing.T) {
 			"with where and descending",
 			"from my-robot a where a = 10 desc;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", nil, nil),
 				newExpression(
@@ -538,6 +546,7 @@ func TestQuery(t *testing.T) {
 			"with where, descending, and paging",
 			"from my-robot a where a = 10 desc limit 10 offset 10;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", nil, nil),
 				newExpression(
@@ -552,6 +561,7 @@ func TestQuery(t *testing.T) {
 			"with multiple where",
 			"from my-robot a where a = 10 and b = 20;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", nil, nil),
 				newExpression(newOrCondition(
@@ -565,6 +575,7 @@ func TestQuery(t *testing.T) {
 			"merge join with where clauses",
 			"from my-robot a, b where a = 10 and b = 20;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", newMJ(newSelect("b", "", nil, nil)), nil),
 				newExpression(newOrCondition(
@@ -579,6 +590,7 @@ func TestQuery(t *testing.T) {
 			"basic as-of join",
 			"from my-robot a precedes b by less than 10 seconds;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", nil, newAJ("precedes", false,
 					newSelect("b", "", nil, nil),
@@ -592,6 +604,7 @@ func TestQuery(t *testing.T) {
 			"as-of join without constraint",
 			"from my-robot a precedes b;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", nil, newAJ("precedes", false, newSelect("b", "", nil, nil), nil)),
 				nil,
@@ -603,6 +616,7 @@ func TestQuery(t *testing.T) {
 			"as-of join without constraint with limit and offset",
 			"from my-robot a precedes b limit 10 offset 10;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", nil, newAJ("precedes", false, newSelect("b", "", nil, nil), nil)),
 				nil,
@@ -614,6 +628,7 @@ func TestQuery(t *testing.T) {
 			"limit/offset reversed",
 			"from my-robot a precedes b offset 10 limit 10;",
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", nil, newAJ("precedes", false, newSelect("b", "", nil, nil), nil)),
 				nil,
@@ -627,6 +642,7 @@ func TestQuery(t *testing.T) {
 			where a.foo = 10 and b.bar = 20
 			limit 10 offset 10;`,
 			newQuery(
+				false,
 				nil,
 				newSelect("a", "", newMJ(newSelect("b", "", nil, nil)), nil),
 				newExpression(newOrCondition(
@@ -685,6 +701,7 @@ func newPagingClause(kvs ...any) []ql.PagingTerm {
 
 // newQuery returns a new query.
 func newQuery(
+	explain bool,
 	between *ql.Between,
 	sel ql.Select,
 	where *ql.Expression,
@@ -692,6 +709,7 @@ func newQuery(
 	paging []ql.PagingTerm,
 ) ql.Query {
 	return ql.Query{
+		Explain:      explain,
 		From:         producer,
 		Between:      between,
 		Select:       sel,

--- a/routes/query.go
+++ b/routes/query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wkalt/dp3/ql"
 	"github.com/wkalt/dp3/rootmap"
 	"github.com/wkalt/dp3/treemgr"
+	"github.com/wkalt/dp3/util"
 	"github.com/wkalt/dp3/util/httputil"
 	"github.com/wkalt/dp3/util/log"
 )
@@ -76,8 +77,11 @@ func newQueryHandler(tmgr *treemgr.TreeManager) http.HandlerFunc {
 			httputil.InternalServerError(ctx, w, "error compiling query: %s", err)
 			return
 		}
+
+		ctx = util.WithContext(ctx, "query")
+
 		log.Debugf(ctx, "compiled query: %s", qp.String())
-		if err := executor.Run(ctx, w, qp, tmgr.NewTreeIterator); err != nil {
+		if err := executor.Run(ctx, w, qp, tmgr.NewTreeIterator, ast.Explain); err != nil {
 			fieldNotFound := executor.FieldNotFoundError{}
 			if errors.As(err, &fieldNotFound) {
 				httputil.BadRequest(ctx, w, "%w", fieldNotFound)


### PR DESCRIPTION
This adds "explain" support to the grammar. When explain is used, the query is still executed but all nodes are wrapped with instrumentation and a tree of timings is sent back to the client in an mcap metadata record. All message/channel/schema data is dropped on the floor.

This also updates the client to render the metadata nicely in that situation.